### PR TITLE
feat(pi): implement hardware control layer for Raspberry Pi

### DIFF
--- a/pi/comms/message_parser.py
+++ b/pi/comms/message_parser.py
@@ -1,1 +1,54 @@
-# Parses incoming commands and outgoing state messages
+import time
+from typing import Optional, Union
+
+from shared.commands.focus_command import FocusCommand
+from shared.commands.move_command import MoveCommand
+from shared.commands.stop_command import StopCommand
+from shared.enums.command_types import CommandType
+from shared.state.telescope_state import TelescopeState
+from pi.utils.logger import get_logger
+
+logger = get_logger("parser")
+
+Command = Union[MoveCommand, FocusCommand, StopCommand]
+
+
+def parse_command(data: dict) -> Optional[Command]:
+    command_type = data.get("command_type")
+
+    if command_type == CommandType.MOVE:
+        return MoveCommand.from_dict(data)
+    elif command_type == CommandType.FOCUS:
+        return FocusCommand.from_dict(data)
+    elif command_type == CommandType.STOP:
+        return StopCommand.from_dict(data)
+
+    logger.warning("Unknown command type: %s", command_type)
+    return None
+
+
+def is_status_request(data: dict) -> bool:
+    return data.get("command_type") == CommandType.STATUS_REQUEST
+
+
+def build_state_response(state: TelescopeState) -> dict:
+    response = state.to_dict()
+    response["message_type"] = "state_report"
+    return response
+
+
+def build_ack_response(command_id: str) -> dict:
+    return {
+        "message_type": "ack",
+        "command_id": command_id,
+        "timestamp": time.time(),
+    }
+
+
+def build_error_response(command_id: str, error_msg: str) -> dict:
+    return {
+        "message_type": "error",
+        "command_id": command_id,
+        "error": error_msg,
+        "timestamp": time.time(),
+    }

--- a/pi/comms/tcp_client.py
+++ b/pi/comms/tcp_client.py
@@ -1,1 +1,132 @@
-# TCP client for connecting to Host, sending/receiving messages
+import queue
+import socket
+import threading
+import time
+from typing import Callable, Optional
+
+from shared.protocols.constants import CONNECT_TIMEOUT_S, RECV_TIMEOUT_S
+from shared.protocols.tcp_protocol import (
+    ProtocolError,
+    recv_message,
+    send_message,
+)
+from pi.config.constants import MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY_S
+from pi.state.error_state import ErrorState
+from shared.errors.error_codes import ErrorCode
+from pi.utils.logger import get_logger
+
+logger = get_logger("tcp_client")
+
+
+class TCPClient:
+    def __init__(self, host: str, port: int, error_state: ErrorState) -> None:
+        self._host = host
+        self._port = port
+        self._errors = error_state
+        self._sock: Optional[socket.socket] = None
+        self._connected = False
+        self._receiver_thread: Optional[threading.Thread] = None
+        self._shutdown = threading.Event()
+        self._lock = threading.Lock()
+
+    def connect(self) -> bool:
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(CONNECT_TIMEOUT_S)
+            sock.connect((self._host, self._port))
+            sock.settimeout(RECV_TIMEOUT_S)
+            with self._lock:
+                self._sock = sock
+                self._connected = True
+            self._errors.clear_error(ErrorCode.COMMS_DISCONNECT)
+            logger.info("Connected to %s:%d", self._host, self._port)
+            return True
+        except (socket.error, OSError) as e:
+            logger.error("Connect failed: %s", e)
+            self._errors.add_error(ErrorCode.COMMS_DISCONNECT, str(e))
+            return False
+
+    def disconnect(self) -> None:
+        self._shutdown.set()
+        with self._lock:
+            self._connected = False
+            if self._sock is not None:
+                try:
+                    self._sock.close()
+                except OSError:
+                    pass
+                self._sock = None
+        if self._receiver_thread is not None and self._receiver_thread.is_alive():
+            self._receiver_thread.join(timeout=2.0)
+        logger.info("Disconnected")
+
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._connected
+
+    def send(self, data: dict) -> bool:
+        with self._lock:
+            if not self._connected or self._sock is None:
+                return False
+            try:
+                send_message(self._sock, data)
+                return True
+            except (ProtocolError, OSError) as e:
+                logger.error("Send failed: %s", e)
+                self._connected = False
+                self._errors.add_error(ErrorCode.COMMS_DISCONNECT, str(e))
+                return False
+
+    def receive(self) -> Optional[dict]:
+        with self._lock:
+            if not self._connected or self._sock is None:
+                return None
+            sock = self._sock
+
+        try:
+            return recv_message(sock)
+        except socket.timeout:
+            return None
+        except (ProtocolError, OSError) as e:
+            logger.error("Receive failed: %s", e)
+            with self._lock:
+                self._connected = False
+            self._errors.add_error(ErrorCode.COMMS_DISCONNECT, str(e))
+            return None
+
+    def start_receiver(self, msg_queue: "queue.Queue[dict]") -> None:
+        self._shutdown.clear()
+        self._receiver_thread = threading.Thread(
+            target=self._receiver_loop,
+            args=(msg_queue,),
+            daemon=True,
+        )
+        self._receiver_thread.start()
+
+    def reconnect(self) -> bool:
+        for attempt in range(1, MAX_RECONNECT_ATTEMPTS + 1):
+            if self._shutdown.is_set():
+                return False
+            logger.info("Reconnect attempt %d/%d", attempt, MAX_RECONNECT_ATTEMPTS)
+            with self._lock:
+                if self._sock is not None:
+                    try:
+                        self._sock.close()
+                    except OSError:
+                        pass
+                    self._sock = None
+                self._connected = False
+            if self.connect():
+                return True
+            time.sleep(RECONNECT_DELAY_S)
+        logger.error("Reconnect failed after %d attempts", MAX_RECONNECT_ATTEMPTS)
+        return False
+
+    def _receiver_loop(self, msg_queue: "queue.Queue[dict]") -> None:
+        while not self._shutdown.is_set():
+            msg = self.receive()
+            if msg is not None:
+                msg_queue.put(msg)
+            elif not self.is_connected():
+                if not self.reconnect():
+                    break

--- a/pi/comms/validator.py
+++ b/pi/comms/validator.py
@@ -1,1 +1,21 @@
-# Validates message structure and command parameters
+from typing import List
+
+from shared.protocols.message_validator import ValidationError, validate_message
+from pi.utils.logger import get_logger
+
+logger = get_logger("validator")
+
+
+def validate_incoming_command(data: dict) -> List[str]:
+    try:
+        errors = validate_message(data)
+        if errors:
+            logger.warning("Validation errors: %s", errors)
+        return errors
+    except ValidationError as e:
+        logger.error("Validation failed: %s", e)
+        return [str(e)]
+
+
+def is_valid_command(data: dict) -> bool:
+    return len(validate_incoming_command(data)) == 0

--- a/pi/config/constants.py
+++ b/pi/config/constants.py
@@ -1,1 +1,29 @@
-# Fixed constants like limits, loop rates, and speed thresholds
+# Motor parameters
+STEPS_PER_DEGREE_ALT = 200.0
+STEPS_PER_DEGREE_AZ = 200.0
+MAX_STEP_RATE_HZ = 1000
+MIN_STEP_RATE_HZ = 10
+ACCEL_STEPS_PER_S2 = 500
+
+# Control loop
+MAIN_LOOP_HZ = 50
+STATE_REPORT_HZ = 5
+WATCHDOG_TIMEOUT_S = 5.0
+
+# Mechanical limits (wider than shared/ protocol limits for homing)
+ALT_MIN_DEG = -5.0
+ALT_MAX_DEG = 95.0
+AZ_MIN_DEG = -5.0
+AZ_MAX_DEG = 365.0
+
+# Focus
+FOCUS_POSITION_MIN = 0
+FOCUS_POSITION_MAX = 10000
+FOCUS_STEPS_PER_DEGREE = 100.0
+
+# Reconnection
+RECONNECT_DELAY_S = 2.0
+MAX_RECONNECT_ATTEMPTS = 10
+
+# Stepping
+STEP_CHUNK_SIZE = 50

--- a/pi/config/pins.py
+++ b/pi/config/pins.py
@@ -1,1 +1,35 @@
-# GPIO pin mappings for motors, sensors, and peripherals
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass(frozen=True)
+class MotorPins:
+    step: int
+    direction: int
+    enable: int
+    fault: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class SensorPins:
+    alt_limit_low: int
+    alt_limit_high: int
+    az_limit_low: int
+    az_limit_high: int
+    alt_encoder_a: Optional[int] = None
+    alt_encoder_b: Optional[int] = None
+    az_encoder_a: Optional[int] = None
+    az_encoder_b: Optional[int] = None
+
+
+# BCM pin assignments (placeholders — update for actual wiring)
+ALT_MOTOR = MotorPins(step=17, direction=27, enable=22, fault=5)
+AZ_MOTOR = MotorPins(step=23, direction=24, enable=25, fault=6)
+FOCUS_MOTOR = MotorPins(step=12, direction=16, enable=20, fault=None)
+
+SENSORS = SensorPins(
+    alt_limit_low=13,
+    alt_limit_high=19,
+    az_limit_low=26,
+    az_limit_high=21,
+)

--- a/pi/control/focus_controller.py
+++ b/pi/control/focus_controller.py
@@ -1,1 +1,70 @@
-# Executes autofocus commands using Pi camera feedback
+from shared.commands.focus_command import FocusCommand, FOCUS_IN, FOCUS_OUT
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.config.constants import FOCUS_POSITION_MAX, FOCUS_POSITION_MIN, MIN_STEP_RATE_HZ
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MotorDriver, DIRECTION_FORWARD, DIRECTION_REVERSE
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+from pi.utils.logger import get_logger
+
+logger = get_logger("focus_ctrl")
+
+
+class FocusController:
+    def __init__(
+        self,
+        focus_motor: MotorDriver,
+        safety: SafetyManager,
+        state_manager: TelescopeStateManager,
+        error_state: ErrorState,
+    ) -> None:
+        self._motor = focus_motor
+        self._safety = safety
+        self._state = state_manager
+        self._errors = error_state
+        self._position = 0
+
+    def execute_focus(self, cmd: FocusCommand) -> bool:
+        direction = DIRECTION_FORWARD if cmd.direction == FOCUS_IN else DIRECTION_REVERSE
+        new_position = self._position + (
+            cmd.steps if cmd.direction == FOCUS_IN else -cmd.steps
+        )
+
+        if new_position < FOCUS_POSITION_MIN:
+            self._errors.add_error(
+                ErrorCode.FOCUS_LIMIT_HIT,
+                f"Focus would go below min ({new_position} < {FOCUS_POSITION_MIN})",
+            )
+            return False
+
+        if new_position > FOCUS_POSITION_MAX:
+            self._errors.add_error(
+                ErrorCode.FOCUS_LIMIT_HIT,
+                f"Focus would exceed max ({new_position} > {FOCUS_POSITION_MAX})",
+            )
+            return False
+
+        self._state.set_status(StatusCode.FOCUSING)
+
+        actual = self._motor.step(
+            direction=direction,
+            num_steps=cmd.steps,
+            rate_hz=MIN_STEP_RATE_HZ,
+            timeout_s=cmd.timeout_s,
+        )
+
+        if actual < cmd.steps:
+            self._errors.add_error(
+                ErrorCode.FOCUS_TIMEOUT,
+                f"Focus timeout: {actual}/{cmd.steps} steps",
+            )
+            # Update position with what we actually moved
+            moved = actual if cmd.direction == FOCUS_IN else -actual
+            self._position += moved
+        else:
+            self._position = new_position
+
+        self._state.set_focus_position(self._position)
+        self._state.set_status(StatusCode.IDLE)
+        return actual == cmd.steps

--- a/pi/control/motor_controller.py
+++ b/pi/control/motor_controller.py
@@ -1,1 +1,141 @@
-# Translates commands into motor actions, applies control logic
+import threading
+from typing import Optional
+
+from shared.commands.move_command import MoveCommand
+from shared.commands.stop_command import StopCommand
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.config.constants import (
+    MAX_STEP_RATE_HZ,
+    MIN_STEP_RATE_HZ,
+    STEP_CHUNK_SIZE,
+    STEPS_PER_DEGREE_ALT,
+    STEPS_PER_DEGREE_AZ,
+)
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MotorDriver, DIRECTION_FORWARD, DIRECTION_REVERSE
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+from pi.utils.logger import get_logger
+
+logger = get_logger("motor_ctrl")
+
+
+class MotorController:
+    def __init__(
+        self,
+        alt_motor: MotorDriver,
+        az_motor: MotorDriver,
+        safety: SafetyManager,
+        state_manager: TelescopeStateManager,
+        error_state: ErrorState,
+    ) -> None:
+        self._alt_motor = alt_motor
+        self._az_motor = az_motor
+        self._safety = safety
+        self._state = state_manager
+        self._errors = error_state
+        self.stop_event = threading.Event()
+
+    def execute_move(self, cmd: MoveCommand) -> bool:
+        if not self._safety.validate_move_target(cmd.target_alt_deg, cmd.target_az_deg):
+            self._errors.add_error(
+                ErrorCode.POSITION_OUT_OF_RANGE,
+                f"Target alt={cmd.target_alt_deg} az={cmd.target_az_deg}",
+            )
+            return False
+
+        self.stop_event.clear()
+        self._state.set_status(StatusCode.MOVING)
+        self._state.set_target(cmd.target_alt_deg, cmd.target_az_deg)
+
+        rate_hz = self._speed_to_rate(cmd.speed)
+        current_alt, current_az = self._state.get_position()
+
+        alt_ok = self._move_axis(
+            motor=self._alt_motor,
+            current_deg=current_alt,
+            target_deg=cmd.target_alt_deg,
+            steps_per_deg=STEPS_PER_DEGREE_ALT,
+            rate_hz=rate_hz,
+            timeout_s=cmd.timeout_s,
+            axis_name="alt",
+        )
+
+        if alt_ok and not self.stop_event.is_set():
+            self._move_axis(
+                motor=self._az_motor,
+                current_deg=current_az,
+                target_deg=cmd.target_az_deg,
+                steps_per_deg=STEPS_PER_DEGREE_AZ,
+                rate_hz=rate_hz,
+                timeout_s=cmd.timeout_s,
+                axis_name="az",
+            )
+
+        if self.stop_event.is_set():
+            self._state.set_status(StatusCode.IDLE)
+            return False
+
+        self._state.update_position(cmd.target_alt_deg, cmd.target_az_deg)
+        self._state.set_status(StatusCode.IDLE)
+        self._state.set_target(None, None)
+        return True
+
+    def execute_stop(self, cmd: StopCommand) -> None:
+        self.stop_event.set()
+        self._alt_motor.stop()
+        self._az_motor.stop()
+
+        if cmd.emergency:
+            self._safety.emergency_stop(
+                cmd.reason if cmd.reason else "Emergency stop command"
+            )
+        else:
+            self._state.set_status(StatusCode.IDLE)
+
+    def _move_axis(
+        self,
+        motor: MotorDriver,
+        current_deg: float,
+        target_deg: float,
+        steps_per_deg: float,
+        rate_hz: float,
+        timeout_s: float,
+        axis_name: str,
+    ) -> bool:
+        delta_deg = target_deg - current_deg
+        if abs(delta_deg) < 1e-6:
+            return True
+
+        direction = DIRECTION_FORWARD if delta_deg > 0 else DIRECTION_REVERSE
+        total_steps = int(abs(delta_deg) * steps_per_deg)
+
+        steps_done = 0
+        while steps_done < total_steps:
+            if self.stop_event.is_set():
+                return False
+
+            chunk = min(STEP_CHUNK_SIZE, total_steps - steps_done)
+            actual = motor.step(
+                direction=direction,
+                num_steps=chunk,
+                rate_hz=rate_hz,
+                timeout_s=timeout_s,
+                stop_event=self.stop_event,
+            )
+            steps_done += actual
+
+            if actual < chunk:
+                self._errors.add_error(
+                    ErrorCode.MOTOR_TIMEOUT,
+                    f"{axis_name} motor timeout at step {steps_done}/{total_steps}",
+                )
+                return False
+
+        return True
+
+    @staticmethod
+    def _speed_to_rate(speed: float) -> float:
+        speed = max(0.0, min(1.0, speed))
+        return MIN_STEP_RATE_HZ + speed * (MAX_STEP_RATE_HZ - MIN_STEP_RATE_HZ)

--- a/pi/control/safety_manager.py
+++ b/pi/control/safety_manager.py
@@ -1,1 +1,112 @@
-# Monitors system limits and prevents unsafe movements
+from typing import List
+
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.config.constants import (
+    ALT_MAX_DEG,
+    ALT_MIN_DEG,
+    AZ_MAX_DEG,
+    AZ_MIN_DEG,
+    WATCHDOG_TIMEOUT_S,
+)
+from pi.hardware.motor_driver import MotorDriver
+from pi.hardware.sensor_reader import SensorReader
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+from pi.utils.logger import get_logger
+from pi.utils.timer import Timeout
+
+logger = get_logger("safety")
+
+
+class SafetyManager:
+    def __init__(
+        self,
+        sensor_reader: SensorReader,
+        state_manager: TelescopeStateManager,
+        error_state: ErrorState,
+        motors: List[MotorDriver],
+    ) -> None:
+        self._sensors = sensor_reader
+        self._state = state_manager
+        self._errors = error_state
+        self._motors = motors
+        self._watchdog = Timeout(WATCHDOG_TIMEOUT_S)
+
+    def check(self) -> bool:
+        safe = True
+
+        if not self._check_limit_switches():
+            safe = False
+
+        if not self._check_position_bounds():
+            safe = False
+
+        if not self._check_watchdog():
+            safe = False
+
+        return safe
+
+    def validate_move_target(self, alt_deg: float, az_deg: float) -> bool:
+        if alt_deg < ALT_MIN_DEG or alt_deg > ALT_MAX_DEG:
+            logger.warning(
+                "Move target alt=%.2f outside bounds [%.1f, %.1f]",
+                alt_deg, ALT_MIN_DEG, ALT_MAX_DEG,
+            )
+            return False
+        if az_deg < AZ_MIN_DEG or az_deg > AZ_MAX_DEG:
+            logger.warning(
+                "Move target az=%.2f outside bounds [%.1f, %.1f]",
+                az_deg, AZ_MIN_DEG, AZ_MAX_DEG,
+            )
+            return False
+        return True
+
+    def emergency_stop(self, reason: str) -> None:
+        logger.error("EMERGENCY STOP: %s", reason)
+        for motor in self._motors:
+            motor.stop()
+            motor.disable()
+        self._errors.add_error(ErrorCode.SAFETY_EMERGENCY_STOP, reason)
+        self._state.set_status(StatusCode.EMERGENCY_STOP)
+
+    def feed_watchdog(self) -> None:
+        self._watchdog.reset()
+
+    def _check_watchdog(self) -> bool:
+        if self._watchdog.is_expired():
+            self._errors.add_error(
+                ErrorCode.SAFETY_WATCHDOG_TIMEOUT, "Watchdog timeout"
+            )
+            self.emergency_stop("Watchdog timeout")
+            return False
+        self._errors.clear_error(ErrorCode.SAFETY_WATCHDOG_TIMEOUT)
+        return True
+
+    def _check_limit_switches(self) -> bool:
+        limits = self._sensors.read_limit_switches()
+        if limits.any_hit:
+            self._errors.add_error(
+                ErrorCode.POSITION_LIMIT_HIT, "Limit switch triggered"
+            )
+            self.emergency_stop("Limit switch triggered")
+            return False
+        self._errors.clear_error(ErrorCode.POSITION_LIMIT_HIT)
+        return True
+
+    def _check_position_bounds(self) -> bool:
+        alt, az = self._state.get_position()
+        if alt < ALT_MIN_DEG or alt > ALT_MAX_DEG:
+            self._errors.add_error(
+                ErrorCode.SAFETY_LIMIT_EXCEEDED,
+                f"Alt {alt:.2f} outside bounds",
+            )
+            return False
+        if az < AZ_MIN_DEG or az > AZ_MAX_DEG:
+            self._errors.add_error(
+                ErrorCode.SAFETY_LIMIT_EXCEEDED,
+                f"Az {az:.2f} outside bounds",
+            )
+            return False
+        self._errors.clear_error(ErrorCode.SAFETY_LIMIT_EXCEEDED)
+        return True

--- a/pi/hardware/gpio_setup.py
+++ b/pi/hardware/gpio_setup.py
@@ -1,1 +1,113 @@
-# Initializes GPIO pins and hardware configurations
+import abc
+from typing import Dict, List
+
+from pi.config.pins import MotorPins, SensorPins
+from pi.utils.logger import get_logger
+
+logger = get_logger("gpio")
+
+OUTPUT = "output"
+INPUT = "input"
+HIGH = 1
+LOW = 0
+
+
+class GPIOProvider(abc.ABC):
+    @abc.abstractmethod
+    def setup_output(self, pin: int) -> None:
+        ...
+
+    @abc.abstractmethod
+    def setup_input(self, pin: int, pull_up: bool = False) -> None:
+        ...
+
+    @abc.abstractmethod
+    def write(self, pin: int, value: int) -> None:
+        ...
+
+    @abc.abstractmethod
+    def read(self, pin: int) -> int:
+        ...
+
+    @abc.abstractmethod
+    def cleanup(self) -> None:
+        ...
+
+
+class MockGPIOProvider(GPIOProvider):
+    def __init__(self) -> None:
+        self._pins: Dict[int, int] = {}
+        self._modes: Dict[int, str] = {}
+
+    def setup_output(self, pin: int) -> None:
+        self._modes[pin] = OUTPUT
+        self._pins[pin] = LOW
+
+    def setup_input(self, pin: int, pull_up: bool = False) -> None:
+        self._modes[pin] = INPUT
+        self._pins[pin] = HIGH if pull_up else LOW
+
+    def write(self, pin: int, value: int) -> None:
+        self._pins[pin] = value
+
+    def read(self, pin: int) -> int:
+        return self._pins.get(pin, LOW)
+
+    def cleanup(self) -> None:
+        self._pins.clear()
+        self._modes.clear()
+
+
+class HardwareGPIOProvider(GPIOProvider):
+    def __init__(self) -> None:
+        try:
+            import RPi.GPIO as GPIO  # type: ignore[import-untyped]
+            self._gpio = GPIO
+            self._gpio.setmode(GPIO.BCM)
+            self._gpio.setwarnings(False)
+        except ImportError:
+            raise RuntimeError(
+                "RPi.GPIO not available — use MockGPIOProvider for testing"
+            )
+
+    def setup_output(self, pin: int) -> None:
+        self._gpio.setup(pin, self._gpio.OUT, initial=self._gpio.LOW)
+
+    def setup_input(self, pin: int, pull_up: bool = False) -> None:
+        pud = self._gpio.PUD_UP if pull_up else self._gpio.PUD_DOWN
+        self._gpio.setup(pin, self._gpio.IN, pull_up_down=pud)
+
+    def write(self, pin: int, value: int) -> None:
+        self._gpio.output(pin, value)
+
+    def read(self, pin: int) -> int:
+        return self._gpio.input(pin)
+
+    def cleanup(self) -> None:
+        self._gpio.cleanup()
+
+
+def initialize_gpio(
+    gpio: GPIOProvider, motor_pins_list: List[MotorPins], sensor_pins: SensorPins
+) -> None:
+    for mp in motor_pins_list:
+        gpio.setup_output(mp.step)
+        gpio.setup_output(mp.direction)
+        gpio.setup_output(mp.enable)
+        if mp.fault is not None:
+            gpio.setup_input(mp.fault, pull_up=True)
+
+    for pin in [
+        sensor_pins.alt_limit_low,
+        sensor_pins.alt_limit_high,
+        sensor_pins.az_limit_low,
+        sensor_pins.az_limit_high,
+    ]:
+        gpio.setup_input(pin, pull_up=True)
+
+    logger.info("GPIO initialized: %d motors, sensors ready", len(motor_pins_list))
+
+
+def cleanup_gpio(gpio: GPIOProvider) -> None:
+    gpio.cleanup()
+    logger.info("GPIO cleaned up")

--- a/pi/hardware/motor_driver.py
+++ b/pi/hardware/motor_driver.py
@@ -1,1 +1,143 @@
-# Low-level motor driver interface for direct hardware control
+import abc
+import threading
+import time
+from typing import List, Optional, Tuple
+
+from pi.config.pins import MotorPins
+from pi.hardware.gpio_setup import GPIOProvider, HIGH, LOW
+from pi.utils.logger import get_logger
+from pi.utils.timer import Timeout
+
+logger = get_logger("motor_driver")
+
+DIRECTION_FORWARD = 1
+DIRECTION_REVERSE = 0
+
+
+class MotorDriver(abc.ABC):
+    @abc.abstractmethod
+    def enable(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def disable(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def step(
+        self,
+        direction: int,
+        num_steps: int,
+        rate_hz: float,
+        timeout_s: float = 30.0,
+        stop_event: Optional[threading.Event] = None,
+    ) -> int:
+        ...
+
+    @abc.abstractmethod
+    def stop(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def is_fault(self) -> bool:
+        ...
+
+
+class StepperMotorDriver(MotorDriver):
+    def __init__(self, gpio: GPIOProvider, pins: MotorPins) -> None:
+        self._gpio = gpio
+        self._pins = pins
+        self._enabled = False
+
+    def enable(self) -> None:
+        self._gpio.write(self._pins.enable, HIGH)
+        self._enabled = True
+
+    def disable(self) -> None:
+        self._gpio.write(self._pins.enable, LOW)
+        self._enabled = False
+
+    def step(
+        self,
+        direction: int,
+        num_steps: int,
+        rate_hz: float,
+        timeout_s: float = 30.0,
+        stop_event: Optional[threading.Event] = None,
+    ) -> int:
+        if not self._enabled:
+            self.enable()
+
+        self._gpio.write(self._pins.direction, direction)
+        period = 1.0 / rate_hz
+        half_period = period / 2.0
+        timeout = Timeout(timeout_s)
+        steps_done = 0
+
+        for _ in range(num_steps):
+            if timeout.is_expired():
+                logger.warning("Step timeout after %d/%d steps", steps_done, num_steps)
+                break
+            if stop_event is not None and stop_event.is_set():
+                break
+
+            self._gpio.write(self._pins.step, HIGH)
+            time.sleep(half_period)
+            self._gpio.write(self._pins.step, LOW)
+            time.sleep(half_period)
+            steps_done += 1
+
+        return steps_done
+
+    def stop(self) -> None:
+        self._gpio.write(self._pins.step, LOW)
+
+    def is_fault(self) -> bool:
+        if self._pins.fault is None:
+            return False
+        return self._gpio.read(self._pins.fault) == LOW
+
+
+class MockMotorDriver(MotorDriver):
+    def __init__(self) -> None:
+        self._enabled = False
+        self._cumulative_steps = 0
+        self._last_direction: Optional[int] = None
+        self._calls: List[Tuple[int, int, float]] = []
+        self._fault = False
+
+    def enable(self) -> None:
+        self._enabled = True
+
+    def disable(self) -> None:
+        self._enabled = False
+
+    def step(
+        self,
+        direction: int,
+        num_steps: int,
+        rate_hz: float,
+        timeout_s: float = 30.0,
+        stop_event: Optional[threading.Event] = None,
+    ) -> int:
+        self._calls.append((direction, num_steps, rate_hz))
+        self._last_direction = direction
+        self._cumulative_steps += num_steps
+        return num_steps
+
+    def stop(self) -> None:
+        pass
+
+    def is_fault(self) -> bool:
+        return self._fault
+
+    def set_fault(self, fault: bool) -> None:
+        self._fault = fault
+
+    @property
+    def cumulative_steps(self) -> int:
+        return self._cumulative_steps
+
+    @property
+    def calls(self) -> List[Tuple[int, int, float]]:
+        return self._calls

--- a/pi/hardware/sensor_reader.py
+++ b/pi/hardware/sensor_reader.py
@@ -1,1 +1,87 @@
-# Reads sensors like encoders, limit switches, and camera triggers
+import abc
+import dataclasses
+from typing import Optional
+
+from pi.config.pins import SensorPins
+from pi.hardware.gpio_setup import GPIOProvider, LOW
+from pi.utils.logger import get_logger
+
+logger = get_logger("sensors")
+
+
+@dataclasses.dataclass
+class LimitSwitchState:
+    alt_low: bool = False
+    alt_high: bool = False
+    az_low: bool = False
+    az_high: bool = False
+
+    @property
+    def any_hit(self) -> bool:
+        return self.alt_low or self.alt_high or self.az_low or self.az_high
+
+
+@dataclasses.dataclass
+class EncoderReading:
+    alt_counts: Optional[int] = None
+    az_counts: Optional[int] = None
+
+
+class SensorReader(abc.ABC):
+    @abc.abstractmethod
+    def read_limit_switches(self) -> LimitSwitchState:
+        ...
+
+    @abc.abstractmethod
+    def read_encoders(self) -> EncoderReading:
+        ...
+
+
+class GPIOSensorReader(SensorReader):
+    def __init__(self, gpio: GPIOProvider, pins: SensorPins) -> None:
+        self._gpio = gpio
+        self._pins = pins
+
+    def read_limit_switches(self) -> LimitSwitchState:
+        return LimitSwitchState(
+            alt_low=self._gpio.read(self._pins.alt_limit_low) == LOW,
+            alt_high=self._gpio.read(self._pins.alt_limit_high) == LOW,
+            az_low=self._gpio.read(self._pins.az_limit_low) == LOW,
+            az_high=self._gpio.read(self._pins.az_limit_high) == LOW,
+        )
+
+    def read_encoders(self) -> EncoderReading:
+        return EncoderReading()
+
+
+class MockSensorReader(SensorReader):
+    def __init__(self) -> None:
+        self._limits = LimitSwitchState()
+        self._encoders = EncoderReading()
+
+    def read_limit_switches(self) -> LimitSwitchState:
+        return self._limits
+
+    def read_encoders(self) -> EncoderReading:
+        return self._encoders
+
+    def set_limits(
+        self,
+        alt_low: bool = False,
+        alt_high: bool = False,
+        az_low: bool = False,
+        az_high: bool = False,
+    ) -> None:
+        self._limits = LimitSwitchState(
+            alt_low=alt_low, alt_high=alt_high,
+            az_low=az_low, az_high=az_high,
+        )
+
+    def set_encoders(
+        self,
+        alt_counts: Optional[int] = None,
+        az_counts: Optional[int] = None,
+    ) -> None:
+        self._encoders = EncoderReading(
+            alt_counts=alt_counts, az_counts=az_counts,
+        )

--- a/pi/main.py
+++ b/pi/main.py
@@ -1,0 +1,190 @@
+import argparse
+import queue
+import signal
+import sys
+import time
+from typing import Optional
+
+from shared.commands.move_command import MoveCommand
+from shared.commands.focus_command import FocusCommand
+from shared.commands.stop_command import StopCommand
+from shared.protocols.constants import DEFAULT_HOST, DEFAULT_PORT
+from pi.comms.message_parser import (
+    build_ack_response,
+    build_error_response,
+    build_state_response,
+    is_status_request,
+    parse_command,
+)
+from pi.comms.tcp_client import TCPClient
+from pi.comms.validator import is_valid_command
+from pi.config.constants import MAIN_LOOP_HZ, STATE_REPORT_HZ
+from pi.config.pins import ALT_MOTOR, AZ_MOTOR, FOCUS_MOTOR, SENSORS
+from pi.control.focus_controller import FocusController
+from pi.control.motor_controller import MotorController
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.gpio_setup import (
+    GPIOProvider,
+    HardwareGPIOProvider,
+    MockGPIOProvider,
+    cleanup_gpio,
+    initialize_gpio,
+)
+from pi.hardware.motor_driver import (
+    MockMotorDriver,
+    MotorDriver,
+    StepperMotorDriver,
+)
+from pi.hardware.sensor_reader import (
+    GPIOSensorReader,
+    MockSensorReader,
+    SensorReader,
+)
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+from pi.utils.logger import get_logger
+from pi.utils.timer import LoopTimer
+
+logger = get_logger("main")
+
+_shutdown = False
+
+
+def _signal_handler(signum: int, frame: object) -> None:
+    global _shutdown
+    logger.info("Received signal %d, shutting down", signum)
+    _shutdown = True
+
+
+def create_hardware(use_mock: bool) -> tuple:
+    if use_mock:
+        gpio: GPIOProvider = MockGPIOProvider()
+        alt_motor: MotorDriver = MockMotorDriver()
+        az_motor: MotorDriver = MockMotorDriver()
+        focus_motor: MotorDriver = MockMotorDriver()
+        sensor_reader: SensorReader = MockSensorReader()
+    else:
+        gpio = HardwareGPIOProvider()
+        initialize_gpio(gpio, [ALT_MOTOR, AZ_MOTOR, FOCUS_MOTOR], SENSORS)
+        alt_motor = StepperMotorDriver(gpio, ALT_MOTOR)
+        az_motor = StepperMotorDriver(gpio, AZ_MOTOR)
+        focus_motor = StepperMotorDriver(gpio, FOCUS_MOTOR)
+        sensor_reader = GPIOSensorReader(gpio, SENSORS)
+
+    return gpio, alt_motor, az_motor, focus_motor, sensor_reader
+
+
+def main_loop(
+    tcp: TCPClient,
+    msg_queue: "queue.Queue[dict]",
+    motor_ctrl: MotorController,
+    focus_ctrl: FocusController,
+    safety: SafetyManager,
+    state_mgr: TelescopeStateManager,
+) -> None:
+    global _shutdown
+    loop_timer = LoopTimer(MAIN_LOOP_HZ)
+    report_interval = 1.0 / STATE_REPORT_HZ
+    last_report = 0.0
+
+    while not _shutdown:
+        safety.feed_watchdog()
+        safety.check()
+
+        # Process incoming messages (non-blocking)
+        try:
+            data = msg_queue.get_nowait()
+        except queue.Empty:
+            data = None
+
+        if data is not None:
+            _dispatch_command(
+                data, tcp, motor_ctrl, focus_ctrl, state_mgr,
+            )
+
+        # Periodic state report
+        now = time.monotonic()
+        if now - last_report >= report_interval:
+            snapshot = state_mgr.get_snapshot()
+            tcp.send(build_state_response(snapshot))
+            last_report = now
+
+        loop_timer.tick()
+
+
+def _dispatch_command(
+    data: dict,
+    tcp: TCPClient,
+    motor_ctrl: MotorController,
+    focus_ctrl: FocusController,
+    state_mgr: TelescopeStateManager,
+) -> None:
+    if is_status_request(data):
+        snapshot = state_mgr.get_snapshot()
+        tcp.send(build_state_response(snapshot))
+        return
+
+    if not is_valid_command(data):
+        cmd_id = data.get("command_id", "unknown")
+        tcp.send(build_error_response(cmd_id, "Invalid command"))
+        return
+
+    cmd = parse_command(data)
+    if cmd is None:
+        return
+
+    tcp.send(build_ack_response(cmd.command_id))
+
+    if isinstance(cmd, MoveCommand):
+        motor_ctrl.execute_move(cmd)
+    elif isinstance(cmd, FocusCommand):
+        focus_ctrl.execute_focus(cmd)
+    elif isinstance(cmd, StopCommand):
+        motor_ctrl.execute_stop(cmd)
+
+
+def run(host: str, port: int, use_mock: bool) -> None:
+    global _shutdown
+    _shutdown = False
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    gpio, alt_motor, az_motor, focus_motor, sensor_reader = create_hardware(use_mock)
+
+    try:
+        error_state = ErrorState()
+        state_mgr = TelescopeStateManager(error_state)
+        motors = [alt_motor, az_motor, focus_motor]
+        safety = SafetyManager(sensor_reader, state_mgr, error_state, motors)
+        motor_ctrl = MotorController(alt_motor, az_motor, safety, state_mgr, error_state)
+        focus_ctrl = FocusController(focus_motor, safety, state_mgr, error_state)
+
+        tcp = TCPClient(host, port, error_state)
+        msg_queue: queue.Queue[dict] = queue.Queue()
+
+        logger.info("Connecting to host %s:%d (mock=%s)", host, port, use_mock)
+        if tcp.connect():
+            tcp.start_receiver(msg_queue)
+            logger.info("Entering main loop at %d Hz", MAIN_LOOP_HZ)
+            main_loop(tcp, msg_queue, motor_ctrl, focus_ctrl, safety, state_mgr)
+        else:
+            logger.error("Failed to connect to host")
+
+        tcp.disconnect()
+    finally:
+        cleanup_gpio(gpio)
+        logger.info("Shutdown complete")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Telescope Pi Controller")
+    parser.add_argument("--host", default="127.0.0.1", help="Host IP address")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Host port")
+    parser.add_argument("--mock", action="store_true", help="Use mock hardware")
+    args = parser.parse_args()
+    run(args.host, args.port, args.mock)
+
+
+if __name__ == "__main__":
+    main()

--- a/pi/state/error_state.py
+++ b/pi/state/error_state.py
@@ -1,1 +1,45 @@
-# Tracks system errors and abnormal conditions
+import threading
+import time
+from typing import Dict, List, Optional, Tuple
+
+from pi.utils.logger import get_logger, log_error_code
+
+logger = get_logger("error_state")
+
+
+class ErrorState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active: Dict[int, str] = {}  # code -> detail
+        self._log: List[Tuple[float, int, str]] = []
+
+    def add_error(self, code: int, detail: str = "") -> None:
+        with self._lock:
+            if code not in self._active:
+                log_error_code(logger, code)
+            self._active[code] = detail
+            self._log.append((time.time(), code, detail))
+
+    def clear_error(self, code: int) -> None:
+        with self._lock:
+            self._active.pop(code, None)
+
+    def clear_all(self) -> None:
+        with self._lock:
+            self._active.clear()
+
+    def has_error(self) -> bool:
+        with self._lock:
+            return len(self._active) > 0
+
+    def has_safety_error(self) -> bool:
+        with self._lock:
+            return any(70 <= code <= 79 for code in self._active)
+
+    def get_active_codes(self) -> List[int]:
+        with self._lock:
+            return list(self._active.keys())
+
+    def get_detail(self, code: int) -> Optional[str]:
+        with self._lock:
+            return self._active.get(code)

--- a/pi/state/telescope_state.py
+++ b/pi/state/telescope_state.py
@@ -1,1 +1,67 @@
-# Tracks current telescope positions, motion state, and focus
+import threading
+from typing import Optional
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from pi.state.error_state import ErrorState
+from pi.utils.logger import get_logger
+
+logger = get_logger("telescope_state")
+
+
+class TelescopeStateManager:
+    def __init__(self, error_state: ErrorState) -> None:
+        self._lock = threading.Lock()
+        self._error_state = error_state
+        self._current_alt = 0.0
+        self._current_az = 0.0
+        self._target_alt: Optional[float] = None
+        self._target_az: Optional[float] = None
+        self._status = StatusCode.IDLE
+        self._focus_position: Optional[int] = None
+        self._is_tracking = False
+
+    def update_position(self, alt_deg: float, az_deg: float) -> None:
+        with self._lock:
+            self._current_alt = alt_deg
+            self._current_az = az_deg
+
+    def set_target(
+        self, alt_deg: Optional[float], az_deg: Optional[float]
+    ) -> None:
+        with self._lock:
+            self._target_alt = alt_deg
+            self._target_az = az_deg
+
+    def set_status(self, status: str) -> None:
+        with self._lock:
+            self._status = status
+
+    def set_focus_position(self, position: Optional[int]) -> None:
+        with self._lock:
+            self._focus_position = position
+
+    def set_tracking(self, tracking: bool) -> None:
+        with self._lock:
+            self._is_tracking = tracking
+
+    def get_position(self) -> tuple:
+        with self._lock:
+            return (self._current_alt, self._current_az)
+
+    def get_status(self) -> str:
+        with self._lock:
+            return self._status
+
+    def get_snapshot(self) -> TelescopeState:
+        with self._lock:
+            return TelescopeState(
+                current_alt_deg=self._current_alt,
+                current_az_deg=self._current_az,
+                status=self._status,
+                target_alt_deg=self._target_alt,
+                target_az_deg=self._target_az,
+                error_codes=self._error_state.get_active_codes(),
+                focus_position=self._focus_position,
+                is_tracking=self._is_tracking,
+            )

--- a/pi/utils/debug_helpers.py
+++ b/pi/utils/debug_helpers.py
@@ -1,1 +1,36 @@
-# Miscellaneous helper functions for debugging and testing
+import os
+from typing import Dict, Any
+
+
+def format_state_summary(state_dict: Dict[str, Any]) -> str:
+    alt = state_dict.get("current_alt_deg", "?")
+    az = state_dict.get("current_az_deg", "?")
+    status = state_dict.get("status", "?")
+    errors = state_dict.get("error_codes", [])
+    return f"alt={alt} az={az} status={status} errors={errors}"
+
+
+def format_command_summary(cmd_dict: Dict[str, Any]) -> str:
+    cmd_type = cmd_dict.get("command_type", "?")
+    cmd_id = cmd_dict.get("command_id", "?")
+    if cmd_type == "move":
+        alt = cmd_dict.get("target_alt_deg", "?")
+        az = cmd_dict.get("target_az_deg", "?")
+        return f"MOVE alt={alt} az={az} id={cmd_id}"
+    elif cmd_type == "focus":
+        direction = cmd_dict.get("direction", "?")
+        steps = cmd_dict.get("steps", "?")
+        return f"FOCUS {direction} steps={steps} id={cmd_id}"
+    elif cmd_type == "stop":
+        emergency = cmd_dict.get("emergency", False)
+        return f"STOP emergency={emergency} id={cmd_id}"
+    return f"{cmd_type} id={cmd_id}"
+
+
+def is_hardware_available() -> bool:
+    try:
+        with open("/proc/device-tree/model", "r") as f:
+            model = f.read()
+        return "Raspberry Pi" in model
+    except (FileNotFoundError, PermissionError, OSError):
+        return False

--- a/pi/utils/logger.py
+++ b/pi/utils/logger.py
@@ -1,1 +1,30 @@
-# Logging utility for messages, errors, and debugging
+import logging
+from typing import Any, Dict
+
+from shared.errors.error_codes import get_error_description
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(f"pi.{name}")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "[PI] %(asctime)s %(name)s %(levelname)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def log_hardware_event(
+    logger: logging.Logger, event: str, details: Dict[str, Any]
+) -> None:
+    parts = [f"{k}={v}" for k, v in details.items()]
+    logger.info("HW_EVENT %s | %s", event, " ".join(parts))
+
+
+def log_error_code(logger: logging.Logger, code: int) -> None:
+    desc = get_error_description(code)
+    logger.error("ERROR %d: %s", code, desc)

--- a/pi/utils/timer.py
+++ b/pi/utils/timer.py
@@ -1,1 +1,38 @@
-# Timing utilities for loops, delays, and scheduled tasks
+import time
+
+
+def monotonic_ms() -> float:
+    return time.monotonic() * 1000.0
+
+
+class LoopTimer:
+    def __init__(self, target_hz: float):
+        self._period = 1.0 / target_hz
+        self._last = time.monotonic()
+
+    def tick(self) -> float:
+        now = time.monotonic()
+        dt = now - self._last
+        sleep_time = self._period - dt
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+        now = time.monotonic()
+        actual_dt = now - self._last
+        self._last = now
+        return actual_dt
+
+
+class Timeout:
+    def __init__(self, timeout_s: float):
+        self._timeout_s = timeout_s
+        self._start = time.monotonic()
+
+    def is_expired(self) -> bool:
+        return time.monotonic() - self._start >= self._timeout_s
+
+    def remaining_s(self) -> float:
+        remaining = self._timeout_s - (time.monotonic() - self._start)
+        return max(0.0, remaining)
+
+    def reset(self) -> None:
+        self._start = time.monotonic()

--- a/tests/pi/test_focus_controller.py
+++ b/tests/pi/test_focus_controller.py
@@ -1,0 +1,73 @@
+from shared.commands.focus_command import FocusCommand, FOCUS_IN, FOCUS_OUT
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.config.constants import FOCUS_POSITION_MAX
+from pi.control.focus_controller import FocusController
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MockMotorDriver
+from pi.hardware.sensor_reader import MockSensorReader
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+
+
+def _make_focus_ctrl():
+    error_state = ErrorState()
+    state_mgr = TelescopeStateManager(error_state)
+    sensors = MockSensorReader()
+    focus_motor = MockMotorDriver()
+    motors = [focus_motor]
+    safety = SafetyManager(sensors, state_mgr, error_state, motors)
+    ctrl = FocusController(focus_motor, safety, state_mgr, error_state)
+    return ctrl, focus_motor, state_mgr, error_state
+
+
+class TestFocusIn:
+    def test_basic_focus_in(self):
+        ctrl, motor, state_mgr, _ = _make_focus_ctrl()
+        cmd = FocusCommand(direction=FOCUS_IN, steps=100)
+        result = ctrl.execute_focus(cmd)
+        assert result is True
+        assert motor.cumulative_steps == 100
+        snap = state_mgr.get_snapshot()
+        assert snap.focus_position == 100
+
+    def test_multiple_focus_in(self):
+        ctrl, motor, state_mgr, _ = _make_focus_ctrl()
+        ctrl.execute_focus(FocusCommand(direction=FOCUS_IN, steps=100))
+        ctrl.execute_focus(FocusCommand(direction=FOCUS_IN, steps=50))
+        snap = state_mgr.get_snapshot()
+        assert snap.focus_position == 150
+
+
+class TestFocusOut:
+    def test_basic_focus_out(self):
+        ctrl, _, state_mgr, _ = _make_focus_ctrl()
+        ctrl.execute_focus(FocusCommand(direction=FOCUS_IN, steps=200))
+        result = ctrl.execute_focus(FocusCommand(direction=FOCUS_OUT, steps=50))
+        assert result is True
+        snap = state_mgr.get_snapshot()
+        assert snap.focus_position == 150
+
+
+class TestFocusLimits:
+    def test_reject_below_min(self):
+        ctrl, _, _, error_state = _make_focus_ctrl()
+        cmd = FocusCommand(direction=FOCUS_OUT, steps=100)
+        result = ctrl.execute_focus(cmd)
+        assert result is False
+        assert ErrorCode.FOCUS_LIMIT_HIT in error_state.get_active_codes()
+
+    def test_reject_above_max(self):
+        ctrl, _, _, error_state = _make_focus_ctrl()
+        cmd = FocusCommand(direction=FOCUS_IN, steps=FOCUS_POSITION_MAX + 1)
+        result = ctrl.execute_focus(cmd)
+        assert result is False
+        assert ErrorCode.FOCUS_LIMIT_HIT in error_state.get_active_codes()
+
+
+class TestFocusStateUpdate:
+    def test_status_returns_to_idle(self):
+        ctrl, _, state_mgr, _ = _make_focus_ctrl()
+        cmd = FocusCommand(direction=FOCUS_IN, steps=10)
+        ctrl.execute_focus(cmd)
+        assert state_mgr.get_status() == StatusCode.IDLE

--- a/tests/pi/test_message_parser.py
+++ b/tests/pi/test_message_parser.py
@@ -1,0 +1,99 @@
+from shared.commands.focus_command import FocusCommand
+from shared.commands.move_command import MoveCommand
+from shared.commands.stop_command import StopCommand
+from shared.enums.command_types import CommandType
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from pi.comms.message_parser import (
+    build_ack_response,
+    build_error_response,
+    build_state_response,
+    is_status_request,
+    parse_command,
+)
+
+
+class TestParseCommand:
+    def test_parse_move(self):
+        data = {
+            "command_type": "move",
+            "target_alt_deg": 45.0,
+            "target_az_deg": 180.0,
+            "speed": 0.5,
+            "command_id": "test-1",
+        }
+        cmd = parse_command(data)
+        assert isinstance(cmd, MoveCommand)
+        assert cmd.target_alt_deg == 45.0
+        assert cmd.target_az_deg == 180.0
+
+    def test_parse_focus(self):
+        data = {
+            "command_type": "focus",
+            "direction": "in",
+            "steps": 100,
+            "command_id": "test-2",
+        }
+        cmd = parse_command(data)
+        assert isinstance(cmd, FocusCommand)
+        assert cmd.direction == "in"
+        assert cmd.steps == 100
+
+    def test_parse_stop(self):
+        data = {
+            "command_type": "stop",
+            "emergency": True,
+            "reason": "test",
+            "command_id": "test-3",
+        }
+        cmd = parse_command(data)
+        assert isinstance(cmd, StopCommand)
+        assert cmd.emergency is True
+
+    def test_parse_unknown_returns_none(self):
+        data = {"command_type": "unknown_cmd"}
+        cmd = parse_command(data)
+        assert cmd is None
+
+    def test_parse_missing_type_returns_none(self):
+        data = {"target_alt_deg": 45.0}
+        cmd = parse_command(data)
+        assert cmd is None
+
+
+class TestIsStatusRequest:
+    def test_status_request(self):
+        assert is_status_request({"command_type": "status_request"}) is True
+
+    def test_not_status_request(self):
+        assert is_status_request({"command_type": "move"}) is False
+
+    def test_missing_type(self):
+        assert is_status_request({}) is False
+
+
+class TestResponseBuilders:
+    def test_build_state_response(self):
+        state = TelescopeState(
+            current_alt_deg=45.0,
+            current_az_deg=180.0,
+            status=StatusCode.IDLE,
+        )
+        resp = build_state_response(state)
+        assert resp["message_type"] == "state_report"
+        assert resp["current_alt_deg"] == 45.0
+        assert resp["current_az_deg"] == 180.0
+        assert resp["status"] == StatusCode.IDLE
+
+    def test_build_ack_response(self):
+        resp = build_ack_response("cmd-123")
+        assert resp["message_type"] == "ack"
+        assert resp["command_id"] == "cmd-123"
+        assert "timestamp" in resp
+
+    def test_build_error_response(self):
+        resp = build_error_response("cmd-456", "something failed")
+        assert resp["message_type"] == "error"
+        assert resp["command_id"] == "cmd-456"
+        assert resp["error"] == "something failed"
+        assert "timestamp" in resp

--- a/tests/pi/test_motor_commands.py
+++ b/tests/pi/test_motor_commands.py
@@ -1,0 +1,109 @@
+from shared.commands.move_command import MoveCommand
+from shared.commands.stop_command import StopCommand
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.config.constants import MIN_STEP_RATE_HZ, MAX_STEP_RATE_HZ, STEPS_PER_DEGREE_ALT
+from pi.control.motor_controller import MotorController
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MockMotorDriver
+from pi.hardware.sensor_reader import MockSensorReader
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+
+
+def _make_motor_ctrl():
+    error_state = ErrorState()
+    state_mgr = TelescopeStateManager(error_state)
+    sensors = MockSensorReader()
+    alt_motor = MockMotorDriver()
+    az_motor = MockMotorDriver()
+    focus_motor = MockMotorDriver()
+    motors = [alt_motor, az_motor, focus_motor]
+    safety = SafetyManager(sensors, state_mgr, error_state, motors)
+    ctrl = MotorController(alt_motor, az_motor, safety, state_mgr, error_state)
+    return ctrl, alt_motor, az_motor, state_mgr, error_state, safety
+
+
+class TestExecuteMove:
+    def test_basic_move(self):
+        ctrl, alt, az, state_mgr, _, _ = _make_motor_ctrl()
+        cmd = MoveCommand(target_alt_deg=10.0, target_az_deg=20.0, speed=0.5)
+        result = ctrl.execute_move(cmd)
+        assert result is True
+        assert alt.cumulative_steps > 0
+        assert az.cumulative_steps > 0
+
+    def test_move_updates_position(self):
+        ctrl, _, _, state_mgr, _, _ = _make_motor_ctrl()
+        cmd = MoveCommand(target_alt_deg=10.0, target_az_deg=20.0)
+        ctrl.execute_move(cmd)
+        snap = state_mgr.get_snapshot()
+        assert snap.current_alt_deg == 10.0
+        assert snap.current_az_deg == 20.0
+
+    def test_move_sets_idle_after_completion(self):
+        ctrl, _, _, state_mgr, _, _ = _make_motor_ctrl()
+        cmd = MoveCommand(target_alt_deg=10.0, target_az_deg=20.0)
+        ctrl.execute_move(cmd)
+        assert state_mgr.get_status() == StatusCode.IDLE
+
+    def test_move_clears_target_after_completion(self):
+        ctrl, _, _, state_mgr, _, _ = _make_motor_ctrl()
+        cmd = MoveCommand(target_alt_deg=10.0, target_az_deg=20.0)
+        ctrl.execute_move(cmd)
+        snap = state_mgr.get_snapshot()
+        assert snap.target_alt_deg is None
+        assert snap.target_az_deg is None
+
+
+class TestSpeedMapping:
+    def test_speed_zero_gives_min_rate(self):
+        rate = MotorController._speed_to_rate(0.0)
+        assert rate == MIN_STEP_RATE_HZ
+
+    def test_speed_one_gives_max_rate(self):
+        rate = MotorController._speed_to_rate(1.0)
+        assert rate == MAX_STEP_RATE_HZ
+
+    def test_speed_half_gives_midpoint(self):
+        rate = MotorController._speed_to_rate(0.5)
+        expected = MIN_STEP_RATE_HZ + 0.5 * (MAX_STEP_RATE_HZ - MIN_STEP_RATE_HZ)
+        assert rate == expected
+
+    def test_speed_clamped_above_one(self):
+        rate = MotorController._speed_to_rate(2.0)
+        assert rate == MAX_STEP_RATE_HZ
+
+    def test_speed_clamped_below_zero(self):
+        rate = MotorController._speed_to_rate(-1.0)
+        assert rate == MIN_STEP_RATE_HZ
+
+
+class TestSafetyReject:
+    def test_rejects_out_of_range_target(self):
+        ctrl, _, _, _, error_state, _ = _make_motor_ctrl()
+        cmd = MoveCommand(target_alt_deg=200.0, target_az_deg=0.0)
+        result = ctrl.execute_move(cmd)
+        assert result is False
+        assert ErrorCode.POSITION_OUT_OF_RANGE in error_state.get_active_codes()
+
+
+class TestStop:
+    def test_stop_sets_idle(self):
+        ctrl, _, _, state_mgr, _, _ = _make_motor_ctrl()
+        cmd = StopCommand()
+        ctrl.execute_stop(cmd)
+        assert state_mgr.get_status() == StatusCode.IDLE
+
+    def test_emergency_stop_sets_emergency(self):
+        ctrl, _, _, state_mgr, error_state, _ = _make_motor_ctrl()
+        cmd = StopCommand(emergency=True, reason="test emergency")
+        ctrl.execute_stop(cmd)
+        assert state_mgr.get_status() == StatusCode.EMERGENCY_STOP
+        assert ErrorCode.SAFETY_EMERGENCY_STOP in error_state.get_active_codes()
+
+    def test_stop_sets_stop_event(self):
+        ctrl, _, _, _, _, _ = _make_motor_ctrl()
+        cmd = StopCommand()
+        ctrl.execute_stop(cmd)
+        assert ctrl.stop_event.is_set()

--- a/tests/pi/test_safety_manager.py
+++ b/tests/pi/test_safety_manager.py
@@ -1,0 +1,97 @@
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MockMotorDriver
+from pi.hardware.sensor_reader import MockSensorReader
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+
+
+def _make_safety():
+    error_state = ErrorState()
+    state_mgr = TelescopeStateManager(error_state)
+    sensors = MockSensorReader()
+    alt_motor = MockMotorDriver()
+    az_motor = MockMotorDriver()
+    focus_motor = MockMotorDriver()
+    motors = [alt_motor, az_motor, focus_motor]
+    safety = SafetyManager(sensors, state_mgr, error_state, motors)
+    return safety, sensors, state_mgr, error_state, motors
+
+
+class TestSafetyCheck:
+    def test_all_clear(self):
+        safety, _, _, error_state, _ = _make_safety()
+        safety.feed_watchdog()
+        assert safety.check() is True
+        assert not error_state.has_error()
+
+    def test_limit_switch_triggers_emergency(self):
+        safety, sensors, _, error_state, _ = _make_safety()
+        safety.feed_watchdog()
+        sensors.set_limits(alt_low=True)
+        assert safety.check() is False
+        assert ErrorCode.POSITION_LIMIT_HIT in error_state.get_active_codes()
+
+    def test_position_out_of_bounds(self):
+        safety, _, state_mgr, error_state, _ = _make_safety()
+        safety.feed_watchdog()
+        state_mgr.update_position(-10.0, 0.0)  # Below ALT_MIN_DEG (-5)
+        assert safety.check() is False
+        assert ErrorCode.SAFETY_LIMIT_EXCEEDED in error_state.get_active_codes()
+
+    def test_watchdog_timeout(self):
+        safety, _, state_mgr, error_state, _ = _make_safety()
+        # Don't feed watchdog — let it expire
+        import time
+        safety._watchdog._timeout_s = 0.01
+        time.sleep(0.02)
+        assert safety.check() is False
+        assert ErrorCode.SAFETY_WATCHDOG_TIMEOUT in error_state.get_active_codes()
+
+
+class TestEmergencyStop:
+    def test_stops_all_motors(self):
+        safety, _, _, error_state, motors = _make_safety()
+        for m in motors:
+            m.enable()
+        safety.emergency_stop("test")
+        for m in motors:
+            assert not m._enabled
+
+    def test_sets_emergency_status(self):
+        safety, _, state_mgr, _, _ = _make_safety()
+        safety.emergency_stop("test reason")
+        assert state_mgr.get_status() == StatusCode.EMERGENCY_STOP
+
+    def test_adds_error_code(self):
+        safety, _, _, error_state, _ = _make_safety()
+        safety.emergency_stop("test")
+        assert ErrorCode.SAFETY_EMERGENCY_STOP in error_state.get_active_codes()
+
+
+class TestValidateMoveTarget:
+    def test_valid_target(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(45.0, 180.0) is True
+
+    def test_alt_too_low(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(-10.0, 180.0) is False
+
+    def test_alt_too_high(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(100.0, 180.0) is False
+
+    def test_az_too_low(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(45.0, -10.0) is False
+
+    def test_az_too_high(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(45.0, 370.0) is False
+
+    def test_boundary_values_accepted(self):
+        safety, _, _, _, _ = _make_safety()
+        assert safety.validate_move_target(-5.0, -5.0) is True
+        assert safety.validate_move_target(95.0, 365.0) is True

--- a/tests/pi/test_sensors.py
+++ b/tests/pi/test_sensors.py
@@ -1,0 +1,73 @@
+from pi.hardware.sensor_reader import (
+    LimitSwitchState,
+    EncoderReading,
+    MockSensorReader,
+)
+
+
+class TestLimitSwitchState:
+    def test_default_all_clear(self):
+        state = LimitSwitchState()
+        assert not state.alt_low
+        assert not state.alt_high
+        assert not state.az_low
+        assert not state.az_high
+        assert not state.any_hit
+
+    def test_any_hit_alt_low(self):
+        state = LimitSwitchState(alt_low=True)
+        assert state.any_hit
+
+    def test_any_hit_alt_high(self):
+        state = LimitSwitchState(alt_high=True)
+        assert state.any_hit
+
+    def test_any_hit_az_low(self):
+        state = LimitSwitchState(az_low=True)
+        assert state.any_hit
+
+    def test_any_hit_az_high(self):
+        state = LimitSwitchState(az_high=True)
+        assert state.any_hit
+
+    def test_multiple_hits(self):
+        state = LimitSwitchState(alt_low=True, az_high=True)
+        assert state.any_hit
+
+
+class TestEncoderReading:
+    def test_default_none(self):
+        reading = EncoderReading()
+        assert reading.alt_counts is None
+        assert reading.az_counts is None
+
+    def test_with_values(self):
+        reading = EncoderReading(alt_counts=100, az_counts=200)
+        assert reading.alt_counts == 100
+        assert reading.az_counts == 200
+
+
+class TestMockSensorReader:
+    def test_default_limits_clear(self):
+        reader = MockSensorReader()
+        limits = reader.read_limit_switches()
+        assert not limits.any_hit
+
+    def test_set_limits(self):
+        reader = MockSensorReader()
+        reader.set_limits(alt_low=True)
+        limits = reader.read_limit_switches()
+        assert limits.alt_low
+        assert limits.any_hit
+
+    def test_default_encoders_none(self):
+        reader = MockSensorReader()
+        encoders = reader.read_encoders()
+        assert encoders.alt_counts is None
+
+    def test_set_encoders(self):
+        reader = MockSensorReader()
+        reader.set_encoders(alt_counts=500, az_counts=1000)
+        encoders = reader.read_encoders()
+        assert encoders.alt_counts == 500
+        assert encoders.az_counts == 1000

--- a/tests/pi/test_state.py
+++ b/tests/pi/test_state.py
@@ -1,0 +1,115 @@
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from shared.state.telescope_state import TelescopeState
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+
+
+class TestErrorState:
+    def test_initially_no_errors(self):
+        es = ErrorState()
+        assert not es.has_error()
+        assert es.get_active_codes() == []
+
+    def test_add_error(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.MOTOR_STALL, "stalled")
+        assert es.has_error()
+        assert ErrorCode.MOTOR_STALL in es.get_active_codes()
+
+    def test_clear_error(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.MOTOR_STALL)
+        es.clear_error(ErrorCode.MOTOR_STALL)
+        assert not es.has_error()
+
+    def test_clear_all(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.MOTOR_STALL)
+        es.add_error(ErrorCode.COMMS_TIMEOUT)
+        es.clear_all()
+        assert not es.has_error()
+
+    def test_deduplicates_active_errors(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.MOTOR_STALL, "first")
+        es.add_error(ErrorCode.MOTOR_STALL, "second")
+        codes = es.get_active_codes()
+        assert codes.count(ErrorCode.MOTOR_STALL) == 1
+        assert es.get_detail(ErrorCode.MOTOR_STALL) == "second"
+
+    def test_has_safety_error(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.MOTOR_STALL)
+        assert not es.has_safety_error()
+        es.add_error(ErrorCode.SAFETY_EMERGENCY_STOP)
+        assert es.has_safety_error()
+
+    def test_safety_error_range(self):
+        es = ErrorState()
+        es.add_error(ErrorCode.SAFETY_LIMIT_EXCEEDED)
+        assert es.has_safety_error()
+        es.clear_all()
+        es.add_error(ErrorCode.SAFETY_WATCHDOG_TIMEOUT)
+        assert es.has_safety_error()
+
+
+class TestTelescopeStateManager:
+    def _make_manager(self):
+        es = ErrorState()
+        return TelescopeStateManager(es), es
+
+    def test_initial_snapshot(self):
+        mgr, _ = self._make_manager()
+        snap = mgr.get_snapshot()
+        assert isinstance(snap, TelescopeState)
+        assert snap.current_alt_deg == 0.0
+        assert snap.current_az_deg == 0.0
+        assert snap.status == StatusCode.IDLE
+
+    def test_update_position(self):
+        mgr, _ = self._make_manager()
+        mgr.update_position(45.0, 180.0)
+        snap = mgr.get_snapshot()
+        assert snap.current_alt_deg == 45.0
+        assert snap.current_az_deg == 180.0
+
+    def test_set_target(self):
+        mgr, _ = self._make_manager()
+        mgr.set_target(30.0, 90.0)
+        snap = mgr.get_snapshot()
+        assert snap.target_alt_deg == 30.0
+        assert snap.target_az_deg == 90.0
+
+    def test_set_status(self):
+        mgr, _ = self._make_manager()
+        mgr.set_status(StatusCode.MOVING)
+        assert mgr.get_status() == StatusCode.MOVING
+        snap = mgr.get_snapshot()
+        assert snap.status == StatusCode.MOVING
+
+    def test_set_focus_position(self):
+        mgr, _ = self._make_manager()
+        mgr.set_focus_position(500)
+        snap = mgr.get_snapshot()
+        assert snap.focus_position == 500
+
+    def test_set_tracking(self):
+        mgr, _ = self._make_manager()
+        mgr.set_tracking(True)
+        snap = mgr.get_snapshot()
+        assert snap.is_tracking is True
+
+    def test_errors_propagate_to_snapshot(self):
+        mgr, es = self._make_manager()
+        es.add_error(ErrorCode.MOTOR_STALL)
+        snap = mgr.get_snapshot()
+        assert ErrorCode.MOTOR_STALL in snap.error_codes
+
+    def test_snapshot_returns_telescope_state_type(self):
+        mgr, _ = self._make_manager()
+        snap = mgr.get_snapshot()
+        assert isinstance(snap, TelescopeState)
+        d = snap.to_dict()
+        assert "current_alt_deg" in d
+        assert "status" in d

--- a/tests/pi/test_tcp_client.py
+++ b/tests/pi/test_tcp_client.py
@@ -1,0 +1,126 @@
+import json
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from shared.protocols.constants import HEADER_SIZE
+from pi.comms.tcp_client import TCPClient
+from pi.state.error_state import ErrorState
+from shared.errors.error_codes import ErrorCode
+
+
+def _make_server():
+    """Create a test TCP server that accepts one connection."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    return server, port
+
+
+def _encode_msg(data: dict) -> bytes:
+    payload = json.dumps(data).encode("utf-8")
+    return struct.pack("!I", len(payload)) + payload
+
+
+class TestTCPClientConnect:
+    def test_connect_success(self):
+        server, port = _make_server()
+        try:
+            es = ErrorState()
+            client = TCPClient("127.0.0.1", port, es)
+            assert client.connect() is True
+            assert client.is_connected()
+        finally:
+            client.disconnect()
+            server.close()
+
+    def test_connect_failure(self):
+        es = ErrorState()
+        client = TCPClient("127.0.0.1", 1, es)
+        assert client.connect() is False
+        assert not client.is_connected()
+        assert ErrorCode.COMMS_DISCONNECT in es.get_active_codes()
+
+    def test_disconnect(self):
+        server, port = _make_server()
+        try:
+            es = ErrorState()
+            client = TCPClient("127.0.0.1", port, es)
+            client.connect()
+            client.disconnect()
+            assert not client.is_connected()
+        finally:
+            server.close()
+
+
+class TestTCPClientSendRecv:
+    def test_send_data(self):
+        server, port = _make_server()
+        try:
+            es = ErrorState()
+            client = TCPClient("127.0.0.1", port, es)
+            client.connect()
+            conn, _ = server.accept()
+
+            msg = {"command_type": "status_request"}
+            assert client.send(msg) is True
+
+            # Read what the server received
+            header = conn.recv(HEADER_SIZE)
+            length = struct.unpack("!I", header)[0]
+            payload = conn.recv(length)
+            received = json.loads(payload)
+            assert received["command_type"] == "status_request"
+
+            conn.close()
+        finally:
+            client.disconnect()
+            server.close()
+
+    def test_receive_data(self):
+        server, port = _make_server()
+        try:
+            es = ErrorState()
+            client = TCPClient("127.0.0.1", port, es)
+            client.connect()
+            conn, _ = server.accept()
+
+            msg = {"message_type": "state_report", "status": "idle"}
+            conn.sendall(_encode_msg(msg))
+
+            received = client.receive()
+            assert received is not None
+            assert received["message_type"] == "state_report"
+
+            conn.close()
+        finally:
+            client.disconnect()
+            server.close()
+
+    def test_receive_timeout_returns_none(self):
+        server, port = _make_server()
+        try:
+            es = ErrorState()
+            client = TCPClient("127.0.0.1", port, es)
+            client.connect()
+            conn, _ = server.accept()
+
+            # Set a very short timeout so we don't wait long
+            client._sock.settimeout(0.1)
+            result = client.receive()
+            assert result is None
+
+            conn.close()
+        finally:
+            client.disconnect()
+            server.close()
+
+    def test_send_when_disconnected(self):
+        es = ErrorState()
+        client = TCPClient("127.0.0.1", 1, es)
+        assert client.send({"test": True}) is False

--- a/tests/pi/test_timer.py
+++ b/tests/pi/test_timer.py
@@ -1,0 +1,68 @@
+import time
+
+import pytest
+
+from pi.utils.timer import LoopTimer, Timeout, monotonic_ms
+
+
+class TestMonotonicMs:
+    def test_returns_milliseconds(self):
+        ms = monotonic_ms()
+        assert ms > 0
+        assert ms == pytest.approx(time.monotonic() * 1000.0, abs=50)
+
+
+class TestLoopTimer:
+    def test_tick_returns_positive_dt(self):
+        timer = LoopTimer(target_hz=100)
+        dt = timer.tick()
+        assert dt > 0
+
+    def test_tick_enforces_rate(self):
+        hz = 50
+        timer = LoopTimer(target_hz=hz)
+        expected_period = 1.0 / hz
+
+        dts = []
+        for _ in range(5):
+            dts.append(timer.tick())
+
+        avg_dt = sum(dts) / len(dts)
+        assert avg_dt == pytest.approx(expected_period, abs=0.01)
+
+    def test_tick_handles_slow_iteration(self):
+        timer = LoopTimer(target_hz=100)
+        time.sleep(0.05)  # Simulate slow work
+        dt = timer.tick()
+        assert dt >= 0.04  # Should not sleep since we're already behind
+
+
+class TestTimeout:
+    def test_not_expired_initially(self):
+        timeout = Timeout(1.0)
+        assert not timeout.is_expired()
+
+    def test_expired_after_duration(self):
+        timeout = Timeout(0.01)
+        time.sleep(0.02)
+        assert timeout.is_expired()
+
+    def test_remaining_decreases(self):
+        timeout = Timeout(1.0)
+        r1 = timeout.remaining_s()
+        time.sleep(0.05)
+        r2 = timeout.remaining_s()
+        assert r2 < r1
+
+    def test_remaining_never_negative(self):
+        timeout = Timeout(0.01)
+        time.sleep(0.02)
+        assert timeout.remaining_s() == 0.0
+
+    def test_reset_restarts_timer(self):
+        timeout = Timeout(0.02)
+        time.sleep(0.03)
+        assert timeout.is_expired()
+        timeout.reset()
+        assert not timeout.is_expired()
+        assert timeout.remaining_s() > 0


### PR DESCRIPTION
## Summary
- Implement all 17 pi/ source files (replacing one-line stubs) across 6 phases: utilities/config, hardware abstraction, state management, control logic, communications, and entry point
- Add 8 test files with 86 tests covering every module — all hardware behind ABCs with mock implementations so no Pi hardware is needed
- Full test suite passes: 163/163 (86 new pi/ + 69 shared/ + 8 host/, zero regressions)

## What's Included

| Layer | Files | Purpose |
|-------|-------|---------|
| `pi/utils/` | logger, timer, debug_helpers | Logging with `[PI]` prefix, fixed-rate loop timer, timeout checker, hardware detection |
| `pi/config/` | constants, pins | Motor params, loop rates, mechanical limits, BCM pin mappings as frozen dataclasses |
| `pi/hardware/` | gpio_setup, motor_driver, sensor_reader | ABCs (`GPIOProvider`, `MotorDriver`, `SensorReader`) + mock and real implementations |
| `pi/state/` | error_state, telescope_state | Thread-safe error accumulator and state manager producing `shared.TelescopeState` snapshots |
| `pi/control/` | safety_manager, motor_controller, focus_controller | Safety checks (limits, bounds, watchdog, e-stop), degree→step motor control, focus with position limits |
| `pi/comms/` | validator, message_parser, tcp_client | Command validation via shared/, command parsing + response builders, TCP client with background receiver and reconnect |
| `pi/main.py` | entry point | Hardware factory (`--mock` flag), 50Hz main loop, signal handlers, CLI interface |

## Key Design Decisions
- **Hardware ABCs with mocks**: All GPIO, motor, and sensor access goes through abstract base classes — `MockGPIOProvider`, `MockMotorDriver`, `MockSensorReader` enable full offline testing
- **Safety-first**: `SafetyManager` checks limit switches, position bounds, and watchdog every loop iteration; `emergency_stop()` disables all motors immediately
- **Chunked stepping**: Motor moves use 50-step chunks with stop_event checks between chunks for responsive cancellation
- **Thread-safe state**: All state managers use `threading.Lock` for safe concurrent access from main loop and receiver thread
- **Shared protocol reuse**: `pi/comms/` delegates to `shared/protocols/` for TCP framing and message validation — no protocol logic duplicated

## Test plan
- [x] `pytest tests/pi/ -v` — all 86 new tests pass
- [x] `pytest tests/ -v` — all 163 tests pass (no regressions)
- [x] `python3 -c "from pi.control.motor_controller import MotorController; print('OK')"` — imports work
- [ ] CI pipeline validates on Python 3.9 and 3.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)