### PR TITLE
chore(project): add persistent progress tracking system

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -2,7 +2,7 @@ Guided commit workflow:
 
 1. Run `git diff --stat` to see what changed
 2. Run `git diff` to review actual changes
-3. Run tests if they exist: `export PYTHONPATH=$PYTHONPATH:$(pwd) && pytest tests/ -v --tb=short`
+3. Run tests if they exist: `export PYTHONPATH=$PYTHONPATH:$(pwd) && python3 -m pytest tests/ -v --tb=short`
 4. Generate a conventional commit message based on changes:
    - feat(scope): for new features
    - fix(scope): for bug fixes
@@ -17,3 +17,14 @@ Guided commit workflow:
 7. After commit, update scratchpad.md with what was done
 
 IMPORTANT: Never push directly to main. If on main, suggest creating a feature branch first.
+
+## Post-Commit: Auto-Save Progress (MANDATORY)
+
+After EVERY successful commit, you MUST immediately:
+
+1. Update docs/PROGRESS.md — move completed items, update test counts, add session log entry
+2. Update .claude/skills/task-board/SKILL.md — check off completed files
+3. Update scratchpad.md — update current task and status
+4. Update MEMORY.md if any architectural decisions were made
+
+This is non-negotiable. Never skip the post-commit save.

--- a/.claude/commands/prime.md
+++ b/.claude/commands/prime.md
@@ -1,10 +1,20 @@
 Re-run the full priming sequence to reload project context:
 
-1. Scan file structure: `find . -maxdepth 3 -type f | head -80`
-2. Read all READMEs: README.md, host/README.md, pi/README.md, shared/README.md
-3. Read MEMORY.md for persistent decisions and architecture
-4. Read scratchpad.md for current task state and blockers
-5. Check git: `git status && git log --oneline -10`
-6. Summarize what you found and suggest the logical next step
+1. Read docs/PROGRESS.md — this is the source of truth for what's done, what's in progress, and what's next
+2. Read MEMORY.md for persistent architectural decisions
+3. Read scratchpad.md for working task state
+4. Read CLAUDE.md for project rules and conventions (already loaded, skim for reminders)
+5. Scan file structure: `find . -maxdepth 3 -type f -name '*.py' | head -80`
+6. Check git: `git status && git log --oneline -10`
+7. Run tests: `export PYTHONPATH=$PWD:$PYTHONPATH && python3 -m pytest tests/ -v --tb=short 2>&1 | tail -30`
+8. Read .claude/skills/task-board/SKILL.md for the implementation checklist
 
-Use this after context compaction, session start, or whenever you feel out of sync with the repo.
+Summarize:
+- Where you left off (from PROGRESS.md session log)
+- Current branch and any uncommitted changes
+- Test status
+- The next logical task to work on
+
+Confirm with the user before proceeding to any work.
+
+IMPORTANT: Use this after context compaction, session start, or whenever you feel out of sync with the repo.

--- a/.claude/commands/save.md
+++ b/.claude/commands/save.md
@@ -1,0 +1,28 @@
+Force-save current progress to all tracking files. Run this anytime to checkpoint your work.
+
+Execute these steps in order:
+
+1. **Update docs/PROGRESS.md**:
+   - Update "Last Updated" date and "Current Status" section
+   - Move any completed items from "In Progress" to "Completed" with date
+   - Update "Next Up" list based on what remains
+   - Add a bullet to the "Session Log" section for today describing what was done
+   - Update test counts and branch info
+
+2. **Update .claude/skills/task-board/SKILL.md**:
+   - Check off any completed items in the implementation checklist
+   - Add new items if scope has expanded
+
+3. **Update scratchpad.md**:
+   - Set "Current Task" to whatever is actively being worked on (or "None" if between tasks)
+   - Update status checkboxes
+   - Update "Next Steps" and "Blockers"
+
+4. **Update MEMORY.md** (only if architectural decisions were made):
+   - Add new decisions with date
+   - Update implementation status
+   - Clear any resolved known issues
+
+5. **Confirm** by printing a summary of what was updated.
+
+IMPORTANT: This same save sequence must run automatically after every commit and at session end. This slash command is a manual trigger for the same process.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,19 +1,21 @@
 Show full project status:
 
-1. Read scratchpad.md — current task, completed steps, blockers
-2. Read MEMORY.md — recent decisions and known issues
-3. Run `git status` — uncommitted changes, current branch
-4. Run `git log --oneline -5` — recent commits
-5. Run `pytest tests/ -v --tb=short 2>&1 | tail -30` — test results (if pytest available)
-6. Count stub files vs implemented files in host/, pi/, shared/
+1. Read docs/PROGRESS.md — source of truth for completed work and next steps
+2. Read .claude/skills/task-board/SKILL.md — implementation checklist
+3. Read scratchpad.md — current task, completed steps, blockers
+4. Read MEMORY.md — recent decisions and known issues
+5. Run `git status` — uncommitted changes, current branch
+6. Run `git log --oneline -5` — recent commits
+7. Run `export PYTHONPATH=$PWD:$PYTHONPATH && python3 -m pytest tests/ -v --tb=short 2>&1 | tail -30` — test results
 
 Present as a clear status report:
 ```
 ## Project Status
+**Last Session**: (from PROGRESS.md session log)
 **Branch**: ...
 **Current Task**: ...
 **Tests**: X passing, Y failing
-**Implementation Progress**: X/Y files implemented
+**Implementation Progress**: X/Y files implemented (from task board)
 **Blockers**: ...
 **Next Step**: ...
 ```

--- a/.claude/skills/task-board/SKILL.md
+++ b/.claude/skills/task-board/SKILL.md
@@ -1,0 +1,79 @@
+# Auto Telescope — Task Board
+
+> Checklist of all implementation work. Updated automatically after every commit.
+
+---
+
+## Layer Implementation
+
+### shared/ — Protocol Contract
+- [x] shared/enums/command_types.py
+- [x] shared/enums/status_codes.py
+- [x] shared/errors/error_codes.py
+- [x] shared/commands/move_command.py
+- [x] shared/commands/focus_command.py
+- [x] shared/commands/stop_command.py
+- [x] shared/state/telescope_state.py
+- [x] shared/state/camera_state.py
+- [x] shared/protocols/constants.py
+- [x] shared/protocols/tcp_protocol.py
+- [x] shared/protocols/message_validator.py
+- [x] tests/shared/test_messages.py (69 tests)
+
+### pi/ — Hardware Control
+- [x] pi/utils/logger.py
+- [x] pi/utils/timer.py
+- [x] pi/utils/debug_helpers.py
+- [x] pi/config/constants.py
+- [x] pi/config/pins.py
+- [x] pi/hardware/gpio_setup.py
+- [x] pi/hardware/motor_driver.py
+- [x] pi/hardware/sensor_reader.py
+- [x] pi/state/error_state.py
+- [x] pi/state/telescope_state.py
+- [x] pi/control/safety_manager.py
+- [x] pi/control/motor_controller.py
+- [x] pi/control/focus_controller.py
+- [x] pi/comms/validator.py
+- [x] pi/comms/message_parser.py
+- [x] pi/comms/tcp_client.py
+- [x] pi/main.py
+- [x] tests/pi/ (8 test files, 86 tests)
+
+### host/ — High-Level Control
+- [x] host/control/desired_position.py (pre-existing)
+- [ ] host/config/constants.py
+- [ ] host/config/ui_params.py
+- [ ] host/utils/logger.py
+- [ ] host/utils/math_helpers.py
+- [ ] host/utils/threading_utils.py
+- [ ] host/comms/tcp_sender.py
+- [ ] host/comms/tcp_receiver.py
+- [ ] host/state/telescope_state.py
+- [ ] host/state/session_log.py
+- [ ] host/control/tracking.py
+- [ ] host/control/focus.py
+- [ ] host/control/error_correction.py
+- [ ] host/ui/manual_control.py
+- [ ] host/ui/auto_control.py
+- [ ] host/ui/display.py
+- [ ] host/simulation/mock_pi.py
+- [ ] host/simulation/sky_model.py
+- [ ] host/main.py
+
+### Integration & Polish
+- [ ] End-to-end host↔pi communication tests
+- [ ] Update README.md (remove Java references)
+- [ ] Fill docs/architecture.md
+- [ ] Add ruff/mypy to dev dependencies
+
+---
+
+## Test Summary
+
+| Layer | Tests | Status |
+|-------|-------|--------|
+| shared/ | 69 | Passing |
+| pi/ | 86 | Passing |
+| host/ | 8 | Passing |
+| **Total** | **163** | **All passing** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,13 @@
 
 When a new session begins, Claude MUST execute this sequence before doing anything else:
 
-1. **Scan repo**: `find . -maxdepth 3 -type f | head -80` for current file structure
-2. **Read READMEs**: Main README.md, host/README.md, pi/README.md, shared/README.md
-3. **Read MEMORY.md**: Load persistent decisions and architectural context
-4. **Read scratchpad.md**: Load current task state, blockers, and next steps
-5. **Check git**: `git status && git log --oneline -10`
-6. **Announce readiness**: Summarize state and suggest next step
+1. **Read docs/PROGRESS.md**: Source of truth — what's done, in progress, next, blockers
+2. **Read MEMORY.md**: Persistent architectural decisions
+3. **Read scratchpad.md**: Current task state and working notes
+4. **Read .claude/skills/task-board/SKILL.md**: Implementation checklist
+5. **Scan repo**: `find . -maxdepth 3 -type f -name '*.py' | head -80`
+6. **Check git**: `git status && git log --oneline -10`
+7. **Announce readiness**: Summarize where you left off and suggest next step
 
 ---
 
@@ -86,6 +87,13 @@ When a prompt starts with `cs` (or no prefix):
 4. scratchpad.md is updated
 5. Conventional commit message: `type(scope): description`
 
+### After EVERY Commit (Non-Negotiable Auto-Save):
+1. Update docs/PROGRESS.md — completed items, test counts, session log
+2. Update .claude/skills/task-board/SKILL.md — check off completed files
+3. Update scratchpad.md — current task, status, next steps
+4. Update MEMORY.md — only if architectural decisions were made
+This is mandatory. Never skip post-commit saves. The `/save` command does the same thing manually.
+
 ### Before ANY PR:
 1. All commit gates above
 2. MEMORY.md updated if architectural decisions were made
@@ -111,9 +119,14 @@ When a prompt starts with `cs` (or no prefix):
 - Critical architectural decisions MUST go in MEMORY.md, not just conversation
 
 ### Surviving compaction:
-- Keep MEMORY.md and scratchpad.md updated after every significant step
-- Use scratchpad.md `## Current Task` as the always-available breadcrumb
+- docs/PROGRESS.md is the primary source of truth — it survives across sessions
+- scratchpad.md `## Current Task` is the always-available breadcrumb
+- .claude/skills/task-board/SKILL.md tracks every file's completion status
 - If confused after compaction, re-run `/prime` to reload full context
+
+### End of Session:
+Before the session ends, ALWAYS run the auto-save sequence (same as post-commit save).
+This ensures the next session can pick up exactly where this one left off.
 
 ---
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,41 +1,49 @@
 # Auto Telescope — Memory
 
 ## Architecture Decisions
-- [2026-02-18] Three-layer architecture: Host (high-level control) ↔ Shared (protocol contract) ↔ Pi (hardware control)
+- [2026-02-18] Three-layer architecture: Host (high-level control) <-> Shared (protocol contract) <-> Pi (hardware control)
 - [2026-02-18] Host is hardware-agnostic. Pi is logic-agnostic. Shared is the single source of truth for messages.
 - [2026-02-18] TCP communication between Host and Pi via shared/protocols/
-- [2026-02-18] Commands flow Host → Pi. State feedback flows Pi → Host. Both use shared/ definitions.
+- [2026-02-18] Commands flow Host -> Pi. State feedback flows Pi -> Host. Both use shared/ definitions.
 - [2026-02-18] Celestial coordinate resolution uses astropy + astroquery (SIMBAD, JPL Horizons)
+- [2026-02-18] Pi hardware behind ABCs (GPIOProvider, MotorDriver, SensorReader) with mock implementations
+- [2026-02-18] SafetyManager is last line of defense — limit switches, position bounds, watchdog, emergency stop
+- [2026-02-18] Motor control uses chunked stepping (50 steps/chunk) with stop_event for responsive cancellation
+- [2026-02-18] Pi main loop runs at 50Hz single-threaded with periodic state reports at 5Hz
 
 ## Hardware
 - Raspberry Pi: Main hardware controller, runs pi/ subsystem
 - Stepper motors: TBD driver (TMC2209 or A4988), controlled via pi/hardware/motor_driver.py
-- GPIO pins: Mapped in pi/config/pins.py (not yet defined)
+- GPIO pins: Mapped in pi/config/pins.py (BCM placeholders: alt=17/27/22/5, az=23/24/25/6, focus=12/16/20)
 - Camera: TBD, will be used for autofocus and plate solving
 
 ## Patterns & Conventions
-- All Python files use stub comments as placeholders: `# Description of what goes here`
-- Only host/control/desired_position.py is fully implemented (celestial coordinate resolution)
 - Tests mirror source structure: tests/host/, tests/pi/, tests/shared/
 - PYTHONPATH must include repo root for imports to work
 - Case-insensitive celestial object name handling with whitespace trimming
-- Three resolution strategies: solar system DB → JPL Horizons → SIMBAD (fallback chain)
+- Three resolution strategies: solar system DB -> JPL Horizons -> SIMBAD (fallback chain)
+- Thread-safe state management using threading.Lock in pi/state/
 
 ## Implementation Status
-- **Implemented**: desired_position.py, test_desired_position.py, CI pipeline, project docs
-- **Stubs only**: All other host/, pi/, shared/ modules (~55 files)
-- **Empty tests**: test_focus.py, test_tracking.py, test_motor_commands.py, test_sensors.py, test_messages.py
-- **Deleted files pending commit**: pytest.ini, scripts/*, tests/shared/test_protocal.py
+- **Complete**: shared/ (11 files, 69 tests), pi/ (17 files, 86 tests), desired_position.py (8 tests)
+- **Stubs only**: ~18 remaining host/ files
+- **Total tests**: 163 passing
+
+## Progress Tracking System
+- docs/PROGRESS.md: Primary session-persistent progress tracker (source of truth)
+- .claude/skills/task-board/SKILL.md: Per-file implementation checklist
+- scratchpad.md: Current task working state
+- MEMORY.md: This file — architectural decisions and learnings
+- /save command: Manual trigger to update all tracking files
+- Auto-save: Runs after every commit and at session end (codified in CLAUDE.md)
 
 ## Known Issues
 - README.md mentions Java but project is pure Python — needs updating
 - docs/architecture.md exists but is empty
-- pytest.ini was deleted from working tree but not committed
-- tests/shared/test_protocal.py has typo in filename ("protocal" → "protocol")
-- CI uses Python 3.9/3.10 but CLAUDE.md tech stack says 3.11+ — should align
-- requirements.txt is minimal (astropy, astroquery, pytest only)
+- RPi.GPIO / gpiozero not in requirements.txt (only needed on actual Pi)
+- Consider adding ruff, mypy to requirements-dev.txt
 
 ## Dependencies
-- astropy: Celestial coordinate transformations (RA/Dec ↔ Alt/Az)
+- astropy: Celestial coordinate transformations (RA/Dec <-> Alt/Az)
 - astroquery: Query JPL Horizons and SIMBAD databases
 - pytest: Test framework

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,94 @@
+# Auto Telescope — Progress Log
+
+> Updated automatically after every commit and at session end.
+> Read this first when starting a new session to know exactly where things stand.
+
+---
+
+## Current Status
+
+**Last Updated**: 2026-02-18
+**Branch**: main
+**Tests**: 163 passing (86 pi/ + 69 shared/ + 8 host/)
+**Overall Progress**: 2 of 5 layers complete
+
+---
+
+## Completed
+
+### shared/ Protocol Layer (2026-02-18)
+- PR #6, merged to main
+- 11 source files + 6 `__init__.py` + 1 test file (69 tests)
+- Defines all commands (Move, Focus, Stop), enums (CommandType, StatusCode), errors (ErrorCode), state (TelescopeState, CameraState), TCP protocol (4-byte length-prefixed JSON), and message validator
+- This is the communication contract consumed by both host/ and pi/
+
+### pi/ Hardware Control Layer (2026-02-18)
+- PR #7, merged to main
+- 17 source files + 8 test files (86 tests)
+- Hardware ABCs (GPIOProvider, MotorDriver, SensorReader) with mock implementations
+- SafetyManager (limit switches, position bounds, watchdog, emergency stop)
+- MotorController (degree-to-step, chunked stepping, stop events)
+- FocusController (focus in/out with position limits)
+- TCPClient (background receiver, reconnect logic)
+- Message parser + response builders (ack/error/state)
+- Main loop: 50Hz single-threaded with periodic state reports
+- CLI: `python3 pi/main.py --mock --host 127.0.0.1`
+
+### Infrastructure (2026-02-18)
+- PR #5, merged to main
+- CLAUDE.md, MEMORY.md, scratchpad.md
+- .claude/commands/ (prime, plan, status, commit, review)
+- .claude/agents/ (hardware-researcher, code-reviewer, test-runner, docs-writer)
+- CI pipeline (.github/workflows/)
+
+### host/control/desired_position.py (pre-existing)
+- Celestial coordinate resolution using astropy + astroquery
+- Three resolution strategies: solar system DB, JPL Horizons, SIMBAD
+- 8 tests passing
+
+---
+
+## In Progress
+
+Nothing currently in progress.
+
+---
+
+## Next Up (Priority Order)
+
+1. **host/comms/** — TCP server + message handling (mirror of pi/comms/ but server-side)
+2. **host/state/** — Telescope state tracking, session logging
+3. **host/control/** — Tracking loop, error correction, focus control (desired_position.py already done)
+4. **host/config/** — Constants, UI params
+5. **host/utils/** — Logger, math helpers, threading utils
+6. **host/ui/** — Manual/auto interface, display
+7. **host/simulation/** — Testing without hardware
+8. **host/main.py** — Entry point, thread coordination
+9. **Integration testing** — End-to-end host↔pi communication tests
+10. **Documentation** — Update README.md (still references Java), fill docs/architecture.md
+
+---
+
+## Blockers
+
+- None currently
+
+---
+
+## Known Issues
+
+- README.md mentions Java but project is pure Python — needs updating
+- docs/architecture.md exists but is empty
+- CI uses Python 3.9/3.10 — requirements.txt is minimal (astropy, astroquery, pytest)
+- RPi.GPIO / gpiozero not in requirements.txt (only needed on Pi hardware)
+- Consider adding ruff, mypy to requirements-dev.txt
+
+---
+
+## Session Log
+
+### Session 2026-02-18
+- Set up Claude Code infrastructure (CLAUDE.md, commands, agents)
+- Implemented shared/ protocol layer (11 files, 69 tests) — PR #6
+- Implemented pi/ hardware control layer (17 files, 86 tests) — PR #7
+- Created progress tracking system (docs/PROGRESS.md, /save command, task board)

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,44 +1,29 @@
 # Scratchpad
 
 ## Current Task
-Shared/ protocol layer implementation — COMPLETE
+None — between tasks. Progress tracking system just set up.
 
 ## Status
-- [x] Repo scan and analysis complete
-- [x] CLAUDE.md created (tailored to actual repo structure)
-- [x] MEMORY.md created (captures current state and decisions)
-- [x] scratchpad.md created (this file)
-- [x] .claude/settings.json created (hooks, permissions)
-- [x] Slash commands created (/prime, /plan, /status, /commit, /review)
-- [x] Subagents created (hardware-researcher, code-reviewer, test-runner, docs-writer)
-- [x] shared/ protocol layer implemented (11 source files + 6 __init__.py + 1 test file = 18 files)
-
-## Completed: shared/ Protocol Layer (2026-02-18)
-- 6x `__init__.py` (shared/, enums/, errors/, commands/, protocols/, state/)
-- `shared/enums/command_types.py` — CommandType str Enum (MOVE, FOCUS, STOP, STATUS_REQUEST)
-- `shared/enums/status_codes.py` — StatusCode str Enum (7 members)
-- `shared/errors/error_codes.py` — ErrorCode IntEnum (22 codes) + descriptions dict
-- `shared/protocols/constants.py` — All magic numbers (port, framing, ranges, timeouts)
-- `shared/commands/move_command.py` — MoveCommand dataclass with to_dict/from_dict
-- `shared/commands/focus_command.py` — FocusCommand dataclass + FOCUS_IN/FOCUS_OUT constants
-- `shared/commands/stop_command.py` — StopCommand dataclass (no timeout — stops are instant)
-- `shared/state/telescope_state.py` — TelescopeState dataclass
-- `shared/state/camera_state.py` — CameraState dataclass
-- `shared/protocols/message_validator.py` — validate_move/focus/stop/message + ValidationError
-- `shared/protocols/tcp_protocol.py` — 4-byte length-prefixed JSON framing + ProtocolError
-- `tests/shared/test_messages.py` — 69 tests, all passing
-- Also added tests/__init__.py and tests/shared/__init__.py
+- [x] Infrastructure: CLAUDE.md, MEMORY.md, scratchpad.md, commands, agents
+- [x] shared/ protocol layer (11 source files, 69 tests) — PR #6 merged
+- [x] pi/ hardware control layer (17 source files, 86 tests) — PR #7 merged
+- [x] Progress tracking system (docs/PROGRESS.md, task board, /save command)
+- [ ] host/ layer implementation (~18 stub files remaining)
+- [ ] Integration testing
+- [ ] Documentation updates
 
 ## Next Steps
-- [ ] Commit shared/ protocol layer on a feature branch
-- [ ] Begin pi/ hardware layer implementation (next logical layer)
-- [ ] Or begin host/ comms layer (depends on shared/ — now unblocked)
+1. host/comms/ — TCP server + message handling (server-side mirror of pi/comms/)
+2. host/state/ — Telescope state tracking, session logging
+3. host/control/ — Tracking loop, error correction, focus
+4. host/config/, host/utils/, host/ui/, host/simulation/, host/main.py
+5. Integration testing and documentation
 
 ## Blockers
 None currently.
 
 ## Notes
-- Python 3.9 compat: must use `Optional[X]`, `List[X]`, `Dict[K,V]` — not `X | None`, `list[x]`, `dict[k,v]`
-- ~44 remaining stub files in host/ and pi/
-- README.md still references Java — needs updating to Python-only
-- Consider adding ruff, mypy to requirements-dev.txt
+- 163 tests passing (86 pi/ + 69 shared/ + 8 host/)
+- Python 3.9 compat: use `Optional[X]`, `List[X]`, `Dict[K,V]`
+- README.md still references Java — needs updating
+- docs/PROGRESS.md is now the primary session-persistent progress tracker


### PR DESCRIPTION
## Summary
- Add `docs/PROGRESS.md` as session-persistent source of truth for project progress
- Add `.claude/skills/task-board/SKILL.md` with per-file implementation checklist
- Add `/save` slash command for manual progress saves
- Update `/prime`, `/commit`, `/status` commands to integrate with tracking files
- Codify auto-save rules in `CLAUDE.md`: progress saved after every commit and at session end

## Test plan
- [ ] `/prime` reads PROGRESS.md and task board on startup
- [ ] `/save` updates all tracking files
- [ ] `/status` shows unified report from all sources
- [ ] No code changes — zero test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)