### PR TITLE
feat(host): implement host control layer

### DIFF
--- a/.claude/skills/task-board/SKILL.md
+++ b/.claude/skills/task-board/SKILL.md
@@ -42,24 +42,25 @@
 
 ### host/ — High-Level Control
 - [x] host/control/desired_position.py (pre-existing)
-- [ ] host/config/constants.py
-- [ ] host/config/ui_params.py
-- [ ] host/utils/logger.py
-- [ ] host/utils/math_helpers.py
-- [ ] host/utils/threading_utils.py
-- [ ] host/comms/tcp_sender.py
-- [ ] host/comms/tcp_receiver.py
-- [ ] host/state/telescope_state.py
-- [ ] host/state/session_log.py
-- [ ] host/control/tracking.py
-- [ ] host/control/focus.py
-- [ ] host/control/error_correction.py
-- [ ] host/ui/manual_control.py
-- [ ] host/ui/auto_control.py
-- [ ] host/ui/display.py
-- [ ] host/simulation/mock_pi.py
-- [ ] host/simulation/sky_model.py
-- [ ] host/main.py
+- [x] host/config/constants.py
+- [x] host/config/ui_params.py
+- [x] host/utils/logger.py
+- [x] host/utils/math_utils.py
+- [x] host/utils/threading_utils.py
+- [x] host/comms/validator.py
+- [x] host/comms/receiver.py
+- [x] host/comms/sender.py
+- [x] host/state/telescope_state.py
+- [x] host/state/session_logs.py
+- [x] host/control/error_correction.py
+- [x] host/control/tracking_controller.py
+- [x] host/control/focus_controller.py
+- [x] host/ui/display.py
+- [x] host/ui/host_interface.py
+- [x] host/simulation/test_data.py
+- [x] host/simulation/simulator.py
+- [x] host/main.py
+- [x] tests/host/ (16 test files, 148 tests)
 
 ### Integration & Polish
 - [ ] End-to-end host↔pi communication tests
@@ -75,5 +76,5 @@
 |-------|-------|--------|
 | shared/ | 69 | Passing |
 | pi/ | 86 | Passing |
-| host/ | 8 | Passing |
-| **Total** | **163** | **All passing** |
+| host/ | 148 | Passing |
+| **Total** | **303** | **All passing** |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,13 +8,25 @@
 ## Current Status
 
 **Last Updated**: 2026-02-18
-**Branch**: main
-**Tests**: 163 passing (86 pi/ + 69 shared/ + 8 host/)
-**Overall Progress**: 2 of 5 layers complete
+**Branch**: feat/host-control-layer
+**Tests**: 303 passing (86 pi/ + 69 shared/ + 148 host/)
+**Overall Progress**: 3 of 5 layers complete
 
 ---
 
 ## Completed
+
+### host/ High-Level Control Layer (2026-02-18)
+- Branch: feat/host-control-layer, pending PR
+- 18 source files + 16 test files (148 tests, including 8 pre-existing)
+- **config/**: constants.py (network, PID, focus, observer defaults), ui_params.py
+- **utils/**: logger.py ([HOST] prefix), math_utils.py (Vincenty angular distance, normalize, clamp, alt_az_delta), threading_utils.py (StoppableThread, PeriodicTask)
+- **state/**: telescope_state.py (HostTelescopeState — thread-safe Pi state store), session_logs.py (circular buffer log)
+- **comms/**: validator.py (outgoing/incoming validation), receiver.py (background recv thread, state_report/ack/error dispatch), sender.py (send_move/focus/stop with validation and ack waiting)
+- **control/**: error_correction.py (PIDController), tracking_controller.py (resolve target, PID tracking loop, sidereal re-resolve), focus_controller.py (coarse-to-fine autofocus)
+- **simulation/**: test_data.py (sample targets, factory functions), simulator.py (in-process Pi mock with slew simulation)
+- **ui/**: display.py (format_state/tracking_info/log), host_interface.py (CLI: move, focus, stop, track, autofocus, status, log, help, quit)
+- **main.py**: TCP server, Pi accept, tracking background thread, argparse (--host/--port/--lat/--lon/--elev/--simulate)
 
 ### shared/ Protocol Layer (2026-02-18)
 - PR #6, merged to main
@@ -56,16 +68,9 @@ Nothing currently in progress.
 
 ## Next Up (Priority Order)
 
-1. **host/comms/** — TCP server + message handling (mirror of pi/comms/ but server-side)
-2. **host/state/** — Telescope state tracking, session logging
-3. **host/control/** — Tracking loop, error correction, focus control (desired_position.py already done)
-4. **host/config/** — Constants, UI params
-5. **host/utils/** — Logger, math helpers, threading utils
-6. **host/ui/** — Manual/auto interface, display
-7. **host/simulation/** — Testing without hardware
-8. **host/main.py** — Entry point, thread coordination
-9. **Integration testing** — End-to-end host↔pi communication tests
-10. **Documentation** — Update README.md (still references Java), fill docs/architecture.md
+1. **Integration testing** — End-to-end host↔pi communication tests
+2. **Documentation** — Update README.md (still references Java), fill docs/architecture.md
+3. **Dev tooling** — Add ruff, mypy to requirements-dev.txt
 
 ---
 
@@ -92,3 +97,7 @@ Nothing currently in progress.
 - Implemented shared/ protocol layer (11 files, 69 tests) — PR #6
 - Implemented pi/ hardware control layer (17 files, 86 tests) — PR #7
 - Created progress tracking system (docs/PROGRESS.md, /save command, task board)
+- Implemented host/ high-level control layer (18 source files, 16 test files, 148 tests)
+  - All 18 stubs replaced with full implementations
+  - TCP server, CLI interface, tracking controller, PID, autofocus, simulator
+  - 303 total tests passing across all layers

--- a/host/comms/receiver.py
+++ b/host/comms/receiver.py
@@ -1,1 +1,92 @@
-# Receives telescope state and camera data from Pi
+import queue
+import socket
+import threading
+from typing import Optional
+
+from shared.protocols.tcp_protocol import ProtocolError, recv_message
+from shared.state.telescope_state import TelescopeState
+from host.state.telescope_state import HostTelescopeState
+from host.state.session_logs import SessionLog
+from host.utils.logger import get_logger, log_state_received
+
+logger = get_logger("receiver")
+
+
+class Receiver:
+    """Receives messages from Pi and dispatches them."""
+
+    def __init__(
+        self,
+        telescope_state: HostTelescopeState,
+        session_log: SessionLog,
+        response_queue: "queue.Queue[dict]",
+    ) -> None:
+        self._telescope_state = telescope_state
+        self._session_log = session_log
+        self._response_queue = response_queue
+        self._shutdown = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._sock: Optional[socket.socket] = None
+
+    def start(self, client_sock: socket.socket) -> None:
+        self._sock = client_sock
+        self._shutdown.clear()
+        self._thread = threading.Thread(
+            target=self._receive_loop,
+            name="host-receiver",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("Receiver started")
+
+    def stop(self) -> None:
+        self._shutdown.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+        logger.info("Receiver stopped")
+
+    def is_alive(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def _receive_loop(self) -> None:
+        while not self._shutdown.is_set():
+            try:
+                msg = recv_message(self._sock)
+            except socket.timeout:
+                continue
+            except (ProtocolError, OSError) as e:
+                if not self._shutdown.is_set():
+                    logger.error("Receive error: %s", e)
+                    self._session_log.log_error("Receive error: %s" % e)
+                break
+
+            if msg is None:
+                logger.warning("Pi disconnected")
+                self._session_log.log_error("Pi disconnected")
+                break
+
+            self._dispatch(msg)
+
+    def _dispatch(self, msg: dict) -> None:
+        msg_type = msg.get("message_type")
+
+        if msg_type == "state_report":
+            try:
+                state = TelescopeState.from_dict(msg)
+                self._telescope_state.update_from_pi(state)
+                self._session_log.log_state(msg)
+                log_state_received(logger, msg)
+            except (KeyError, TypeError, ValueError) as e:
+                logger.error("Bad state report: %s", e)
+                self._session_log.log_error("Bad state report: %s" % e)
+
+        elif msg_type in ("ack", "error"):
+            self._response_queue.put(msg)
+            if msg_type == "error":
+                logger.warning(
+                    "Error from Pi: %s (cmd=%s)",
+                    msg.get("error", "?"),
+                    msg.get("command_id", "?"),
+                )
+        else:
+            logger.warning("Unknown message type: %s", msg_type)

--- a/host/comms/sender.py
+++ b/host/comms/sender.py
@@ -1,1 +1,116 @@
-# Sends commands to Pi based on controller outputs
+import queue
+import socket
+import threading
+import time
+from typing import Optional
+
+from shared.commands.move_command import MoveCommand
+from shared.commands.focus_command import FocusCommand, FOCUS_IN, FOCUS_OUT
+from shared.commands.stop_command import StopCommand
+from shared.enums.command_types import CommandType
+from shared.protocols.tcp_protocol import ProtocolError, send_message
+from host.comms.validator import validate_outgoing_command
+from host.config.constants import COMMAND_ACK_TIMEOUT_S
+from host.state.session_logs import SessionLog
+from host.utils.logger import get_logger, log_command_sent
+
+logger = get_logger("sender")
+
+
+class Sender:
+    """Sends commands to Pi over TCP."""
+
+    def __init__(
+        self,
+        session_log: SessionLog,
+        response_queue: "queue.Queue[dict]",
+    ) -> None:
+        self._session_log = session_log
+        self._response_queue = response_queue
+        self._sock: Optional[socket.socket] = None
+        self._lock = threading.Lock()
+
+    def set_socket(self, sock: socket.socket) -> None:
+        with self._lock:
+            self._sock = sock
+
+    def send_move(
+        self, alt: float, az: float, speed: float = 0.5
+    ) -> Optional[str]:
+        cmd = MoveCommand(target_alt_deg=alt, target_az_deg=az, speed=speed)
+        return self._send_command(cmd.to_dict(), cmd.command_id)
+
+    def send_focus(self, direction: str, steps: int) -> Optional[str]:
+        cmd = FocusCommand(direction=direction, steps=steps)
+        return self._send_command(cmd.to_dict(), cmd.command_id)
+
+    def send_stop(self, emergency: bool = False) -> Optional[str]:
+        cmd = StopCommand(emergency=emergency)
+        return self._send_command(cmd.to_dict(), cmd.command_id)
+
+    def send_status_request(self) -> bool:
+        data = {
+            "command_type": CommandType.STATUS_REQUEST,
+            "timestamp": time.time(),
+        }
+        with self._lock:
+            if self._sock is None:
+                return False
+            try:
+                send_message(self._sock, data)
+                return True
+            except (ProtocolError, OSError) as e:
+                logger.error("Status request send failed: %s", e)
+                return False
+
+    def wait_for_ack(
+        self, command_id: str, timeout: Optional[float] = None
+    ) -> Optional[dict]:
+        if timeout is None:
+            timeout = COMMAND_ACK_TIMEOUT_S
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                msg = self._response_queue.get(timeout=min(remaining, 0.5))
+            except queue.Empty:
+                continue
+            if msg.get("command_id") == command_id:
+                return msg
+            # Put back if not ours (unlikely but safe)
+            self._response_queue.put(msg)
+        logger.warning("Ack timeout for command %s", command_id)
+        return None
+
+    def _send_command(self, data: dict, command_id: str) -> Optional[str]:
+        errors = validate_outgoing_command(data)
+        if errors:
+            logger.error("Validation failed: %s", errors)
+            self._session_log.log_error(
+                "Validation failed", {"errors": errors}
+            )
+            return None
+
+        with self._lock:
+            if self._sock is None:
+                logger.error("No socket, cannot send")
+                return None
+            try:
+                send_message(self._sock, data)
+            except (ProtocolError, OSError) as e:
+                logger.error("Send failed: %s", e)
+                self._session_log.log_error("Send failed: %s" % e)
+                return None
+
+        log_command_sent(
+            logger,
+            data.get("command_type", "unknown"),
+            {"id": command_id},
+        )
+        self._session_log.log_command(
+            data.get("command_type", "unknown"),
+            {"command_id": command_id},
+        )
+        return command_id

--- a/host/comms/validator.py
+++ b/host/comms/validator.py
@@ -1,1 +1,35 @@
- # Validates incoming/outgoing messages using Shared definitions
+from typing import List
+
+from shared.protocols.message_validator import ValidationError, validate_message
+from host.utils.logger import get_logger
+
+logger = get_logger("validator")
+
+
+def validate_outgoing_command(data: dict) -> List[str]:
+    try:
+        errors = validate_message(data)
+        if errors:
+            logger.warning("Outgoing validation errors: %s", errors)
+        return errors
+    except ValidationError as e:
+        logger.error("Outgoing validation failed: %s", e)
+        return [str(e)]
+
+
+def validate_incoming_response(data: dict) -> List[str]:
+    msg_type = data.get("message_type")
+    errors = []
+    if msg_type not in ("ack", "error", "state_report"):
+        errors.append("Unknown message_type: %s" % msg_type)
+    if msg_type == "ack" and "command_id" not in data:
+        errors.append("Ack missing command_id")
+    if msg_type == "error" and "error" not in data:
+        errors.append("Error response missing error field")
+    if errors:
+        logger.warning("Incoming validation errors: %s", errors)
+    return errors
+
+
+def is_valid_command(data: dict) -> bool:
+    return len(validate_outgoing_command(data)) == 0

--- a/host/config/constants.py
+++ b/host/config/constants.py
@@ -1,1 +1,24 @@
-# Physical, system, or tuning constants (PID gains, limits, thresholds)
+# Network
+SERVER_HOST = "0.0.0.0"
+SERVER_PORT = 5050
+
+# Tracking / PID
+TRACKING_LOOP_HZ = 10
+PID_KP = 1.0
+PID_KI = 0.0
+PID_KD = 0.1
+TRACKING_TOLERANCE_DEG = 0.01
+
+# Focus
+FOCUS_SEARCH_STEPS = [100, 50, 25, 10]
+FOCUS_METRIC_THRESHOLD = 0.05
+
+# Safety / heartbeat
+PI_HEARTBEAT_TIMEOUT_S = 10.0
+MAX_COMMAND_RETRIES = 3
+COMMAND_ACK_TIMEOUT_S = 5.0
+
+# Observer defaults — Mountain View, CA
+DEFAULT_OBSERVER_LAT = 37.3861
+DEFAULT_OBSERVER_LON = -122.0839
+DEFAULT_OBSERVER_ELEV = 32.0

--- a/host/config/ui_params.py
+++ b/host/config/ui_params.py
@@ -1,1 +1,8 @@
- # UI-related constants (window size, update rates)
+# Display refresh
+DISPLAY_REFRESH_HZ = 2
+
+# Formatting
+STATUS_LINE_WIDTH = 60
+
+# CLI
+PROMPT_STRING = "telescope> "

--- a/host/control/error_correction.py
+++ b/host/control/error_correction.py
@@ -1,1 +1,58 @@
-# Handles deviations, PID adjustments, corrections
+import time
+from typing import Optional
+
+from host.utils.math_utils import clamp
+
+
+class PIDController:
+    """PID controller for tracking error correction."""
+
+    def __init__(
+        self,
+        kp: float = 1.0,
+        ki: float = 0.0,
+        kd: float = 0.1,
+        output_min: float = 0.0,
+        output_max: float = 1.0,
+    ) -> None:
+        self._kp = kp
+        self._ki = ki
+        self._kd = kd
+        self._output_min = output_min
+        self._output_max = output_max
+        self._integral = 0.0
+        self._prev_error: Optional[float] = None
+        self._prev_time: Optional[float] = None
+
+    def compute(self, error: float) -> float:
+        now = time.monotonic()
+
+        if self._prev_time is None:
+            dt = 0.0
+        else:
+            dt = now - self._prev_time
+
+        # Proportional
+        p_term = self._kp * error
+
+        # Integral
+        if dt > 0:
+            self._integral += error * dt
+        i_term = self._ki * self._integral
+
+        # Derivative
+        if self._prev_error is not None and dt > 0:
+            d_term = self._kd * (error - self._prev_error) / dt
+        else:
+            d_term = 0.0
+
+        self._prev_error = error
+        self._prev_time = now
+
+        output = p_term + i_term + d_term
+        return clamp(output, self._output_min, self._output_max)
+
+    def reset(self) -> None:
+        self._integral = 0.0
+        self._prev_error = None
+        self._prev_time = None

--- a/host/control/focus_controller.py
+++ b/host/control/focus_controller.py
@@ -1,1 +1,111 @@
- # Autofocus algorithm using camera input
+from typing import List, Optional
+
+from shared.commands.focus_command import FOCUS_IN, FOCUS_OUT
+from host.comms.sender import Sender
+from host.config.constants import FOCUS_METRIC_THRESHOLD, FOCUS_SEARCH_STEPS
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from host.utils.logger import get_logger
+
+logger = get_logger("focus_ctrl")
+
+
+class FocusController:
+    """Autofocus using coarse-to-fine search."""
+
+    def __init__(
+        self,
+        sender: Sender,
+        telescope_state: HostTelescopeState,
+        session_log: SessionLog,
+    ) -> None:
+        self._sender = sender
+        self._state = telescope_state
+        self._session_log = session_log
+        self._running = False
+        self._best_metric: float = 0.0
+        self._best_position: Optional[int] = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    def run_autofocus(
+        self, step_sizes: Optional[List[int]] = None
+    ) -> bool:
+        if step_sizes is None:
+            step_sizes = list(FOCUS_SEARCH_STEPS)
+
+        self._running = True
+        self._best_metric = self._get_focus_metric()
+        self._best_position = self._get_focus_position()
+        improved = False
+
+        logger.info("Autofocus started (steps=%s)", step_sizes)
+        self._session_log.log_command("autofocus_start", {"steps": step_sizes})
+
+        try:
+            for step_size in step_sizes:
+                got_better = self._search_step(step_size)
+                if got_better:
+                    improved = True
+        finally:
+            self._running = False
+
+        logger.info(
+            "Autofocus complete: improved=%s best_pos=%s metric=%.4f",
+            improved, self._best_position, self._best_metric,
+        )
+        self._session_log.log_command(
+            "autofocus_done",
+            {"improved": improved, "best_position": self._best_position},
+        )
+        return improved
+
+    def _search_step(self, step_size: int) -> bool:
+        improved = False
+
+        # Try focus in
+        self._sender.send_focus(FOCUS_IN, step_size)
+        metric_in = self._get_focus_metric()
+
+        if metric_in > self._best_metric + FOCUS_METRIC_THRESHOLD:
+            self._best_metric = metric_in
+            self._best_position = self._get_focus_position()
+            improved = True
+            logger.debug("Focus IN by %d improved metric to %.4f", step_size, metric_in)
+        else:
+            # Undo and try out
+            self._sender.send_focus(FOCUS_OUT, step_size)
+            self._sender.send_focus(FOCUS_OUT, step_size)
+            metric_out = self._get_focus_metric()
+
+            if metric_out > self._best_metric + FOCUS_METRIC_THRESHOLD:
+                self._best_metric = metric_out
+                self._best_position = self._get_focus_position()
+                improved = True
+                logger.debug("Focus OUT by %d improved metric to %.4f", step_size, metric_out)
+            else:
+                # Return to original
+                self._sender.send_focus(FOCUS_IN, step_size)
+
+        return improved
+
+    def _get_focus_metric(self) -> float:
+        """Get current focus quality metric from telescope state.
+
+        In production, this would analyze camera images (e.g. Laplacian variance).
+        For now, uses focus_position as a proxy — closer to midrange is better.
+        """
+        state = self._state.get_latest()
+        if state is None or state.focus_position is None:
+            return 0.0
+        pos = state.focus_position
+        # Proxy: peak at midpoint of 0-10000 range
+        return 1.0 - abs(pos - 5000) / 5000.0
+
+    def _get_focus_position(self) -> Optional[int]:
+        state = self._state.get_latest()
+        if state is None:
+            return None
+        return state.focus_position

--- a/host/control/tracking_controller.py
+++ b/host/control/tracking_controller.py
@@ -1,1 +1,160 @@
-# Computes telescope movements based on current & target positions
+from typing import Callable, Dict, Optional
+
+from host.comms.sender import Sender
+from host.config.constants import (
+    PID_KP,
+    PID_KI,
+    PID_KD,
+    TRACKING_TOLERANCE_DEG,
+)
+from host.control.error_correction import PIDController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from host.utils.logger import get_logger
+from host.utils.math_utils import angular_distance, alt_az_delta
+
+logger = get_logger("tracking")
+
+
+class TrackingController:
+    """Resolves celestial targets and drives the telescope to track them."""
+
+    def __init__(
+        self,
+        sender: Sender,
+        telescope_state: HostTelescopeState,
+        session_log: SessionLog,
+        lat: float,
+        lon: float,
+        elev: float,
+        coordinate_resolver: Optional[Callable] = None,
+    ) -> None:
+        self._sender = sender
+        self._state = telescope_state
+        self._session_log = session_log
+        self._lat = lat
+        self._lon = lon
+        self._elev = elev
+        self._resolve = coordinate_resolver or self._default_resolver
+        self._pid = PIDController(
+            kp=PID_KP, ki=PID_KI, kd=PID_KD,
+            output_min=0.05, output_max=1.0,
+        )
+        self._tracking = False
+        self._target_name: Optional[str] = None
+        self._target_alt: Optional[float] = None
+        self._target_az: Optional[float] = None
+
+    @staticmethod
+    def _default_resolver(name: str, lat: float, lon: float, elev: float) -> tuple:
+        from host.control.desired_position import get_object_coordinates
+        return get_object_coordinates(name, lat, lon, elev)
+
+    def start_tracking(self, target_name: str) -> bool:
+        try:
+            ra, dec, alt, az, visible = self._resolve(
+                target_name, self._lat, self._lon, self._elev,
+            )
+        except (ValueError, Exception) as e:
+            logger.error("Cannot resolve target '%s': %s", target_name, e)
+            self._session_log.log_error(
+                "Target resolution failed: %s" % e,
+                {"target": target_name},
+            )
+            return False
+
+        if not visible:
+            logger.warning("Target '%s' is below the horizon (alt=%.2f)", target_name, alt)
+            self._session_log.log_error(
+                "Target below horizon",
+                {"target": target_name, "alt": alt},
+            )
+            return False
+
+        self._target_name = target_name
+        self._target_alt = alt
+        self._target_az = az
+        self._tracking = True
+        self._pid.reset()
+        self._state.set_tracking_target(target_name)
+
+        logger.info(
+            "Tracking started: %s at alt=%.2f az=%.2f",
+            target_name, alt, az,
+        )
+        self._session_log.log_command(
+            "track_start",
+            {"target": target_name, "alt": alt, "az": az},
+        )
+        return True
+
+    def stop_tracking(self) -> None:
+        if self._tracking:
+            self._sender.send_stop(emergency=False)
+        self._tracking = False
+        self._target_name = None
+        self._target_alt = None
+        self._target_az = None
+        self._pid.reset()
+        self._state.clear_tracking_target()
+        logger.info("Tracking stopped")
+
+    @property
+    def is_tracking(self) -> bool:
+        return self._tracking
+
+    def update(self) -> None:
+        if not self._tracking or self._target_name is None:
+            return
+
+        # Re-resolve target position (sidereal motion)
+        try:
+            ra, dec, alt, az, visible = self._resolve(
+                self._target_name, self._lat, self._lon, self._elev,
+            )
+        except Exception as e:
+            logger.error("Re-resolve failed: %s", e)
+            return
+
+        if not visible:
+            logger.warning("Target '%s' set below horizon, stopping", self._target_name)
+            self.stop_tracking()
+            return
+
+        self._target_alt = alt
+        self._target_az = az
+
+        # Get current position from Pi
+        pos = self._state.get_position()
+        if pos is None:
+            return
+        cur_alt, cur_az = pos
+
+        # Compute error
+        distance = angular_distance(cur_alt, cur_az, alt, az)
+
+        if distance < TRACKING_TOLERANCE_DEG:
+            return
+
+        speed = self._pid.compute(distance)
+        d_alt, d_az = alt_az_delta(cur_alt, cur_az, alt, az)
+
+        self._sender.send_move(alt, az, speed)
+
+    def get_tracking_info(self) -> Dict:
+        pos = self._state.get_position()
+        cur_alt = pos[0] if pos else 0.0
+        cur_az = pos[1] if pos else 0.0
+        t_alt = self._target_alt if self._target_alt is not None else 0.0
+        t_az = self._target_az if self._target_az is not None else 0.0
+
+        distance = angular_distance(cur_alt, cur_az, t_alt, t_az) if self._tracking else 0.0
+
+        return {
+            "tracking": self._tracking,
+            "target": self._target_name or "",
+            "target_alt": t_alt,
+            "target_az": t_az,
+            "error_deg": distance,
+            "within_tolerance": distance < TRACKING_TOLERANCE_DEG,
+        }

--- a/host/main.py
+++ b/host/main.py
@@ -1,0 +1,242 @@
+import argparse
+import queue
+import signal
+import socket
+import sys
+import threading
+import time
+from typing import Optional
+
+from shared.protocols.constants import DEFAULT_PORT, RECV_TIMEOUT_S
+from host.comms.receiver import Receiver
+from host.comms.sender import Sender
+from host.config.constants import (
+    DEFAULT_OBSERVER_ELEV,
+    DEFAULT_OBSERVER_LAT,
+    DEFAULT_OBSERVER_LON,
+    SERVER_HOST,
+    TRACKING_LOOP_HZ,
+)
+from host.control.focus_controller import FocusController
+from host.control.tracking_controller import TrackingController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from host.ui.host_interface import HostInterface
+from host.utils.logger import get_logger
+
+logger = get_logger("main")
+
+_shutdown = False
+
+
+def _signal_handler(signum: int, frame: object) -> None:
+    global _shutdown
+    logger.info("Received signal %d, shutting down", signum)
+    _shutdown = True
+
+
+def start_tcp_server(host: str, port: int) -> socket.socket:
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((host, port))
+    server.listen(1)
+    server.settimeout(1.0)
+    logger.info("TCP server listening on %s:%d", host, port)
+    return server
+
+
+def wait_for_pi(server: socket.socket) -> Optional[socket.socket]:
+    global _shutdown
+    logger.info("Waiting for Pi to connect...")
+    while not _shutdown:
+        try:
+            client_sock, addr = server.accept()
+            client_sock.settimeout(RECV_TIMEOUT_S)
+            logger.info("Pi connected from %s:%d", addr[0], addr[1])
+            return client_sock
+        except socket.timeout:
+            continue
+        except OSError as e:
+            if not _shutdown:
+                logger.error("Accept error: %s", e)
+            break
+    return None
+
+
+def tracking_loop(
+    tracking: TrackingController,
+    stop_event: threading.Event,
+) -> None:
+    interval = 1.0 / TRACKING_LOOP_HZ
+    while not stop_event.is_set():
+        start = time.monotonic()
+        try:
+            tracking.update()
+        except Exception as e:
+            logger.error("Tracking update error: %s", e)
+        elapsed = time.monotonic() - start
+        sleep_time = interval - elapsed
+        if sleep_time > 0:
+            stop_event.wait(timeout=sleep_time)
+
+
+def run(
+    host: str,
+    port: int,
+    lat: float,
+    lon: float,
+    elev: float,
+    simulate: bool = False,
+) -> None:
+    global _shutdown
+    _shutdown = False
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    # Shared state
+    telescope_state = HostTelescopeState()
+    session_log = SessionLog()
+    response_queue: queue.Queue[dict] = queue.Queue()
+
+    # Comms
+    sender = Sender(session_log, response_queue)
+    receiver = Receiver(telescope_state, session_log, response_queue)
+
+    # Control
+    tracking = TrackingController(
+        sender, telescope_state, session_log, lat, lon, elev,
+    )
+    focus = FocusController(sender, telescope_state, session_log)
+
+    # UI
+    interface = HostInterface(
+        sender, tracking, focus, telescope_state, session_log,
+    )
+
+    if simulate:
+        _run_simulated(
+            sender, receiver, tracking, focus,
+            telescope_state, session_log, interface,
+        )
+        return
+
+    # Real TCP mode
+    server = start_tcp_server(host, port)
+    try:
+        client_sock = wait_for_pi(server)
+        if client_sock is None:
+            logger.error("No Pi connection, exiting")
+            return
+
+        sender.set_socket(client_sock)
+        receiver.start(client_sock)
+
+        # Start tracking background thread
+        track_stop = threading.Event()
+        track_thread = threading.Thread(
+            target=tracking_loop,
+            args=(tracking, track_stop),
+            name="tracking-loop",
+            daemon=True,
+        )
+        track_thread.start()
+
+        try:
+            interface.run()
+        finally:
+            _shutdown = True
+            track_stop.set()
+            tracking.stop_tracking()
+            receiver.stop()
+            track_thread.join(timeout=2.0)
+            client_sock.close()
+    finally:
+        server.close()
+        logger.info("Shutdown complete")
+
+
+def _run_simulated(
+    sender, receiver, tracking, focus,
+    telescope_state, session_log, interface,
+) -> None:
+    from host.simulation.simulator import TelescopeSimulator
+
+    logger.info("Running in simulation mode")
+    sim = TelescopeSimulator()
+
+    # Override sender to route through simulator
+    class SimSender:
+        def __init__(self, real_sender, simulator, ts):
+            self._real = real_sender
+            self._sim = simulator
+            self._ts = ts
+
+        def send_move(self, alt, az, speed=0.5):
+            from shared.commands.move_command import MoveCommand
+            cmd = MoveCommand(target_alt_deg=alt, target_az_deg=az, speed=speed)
+            resp = self._sim.send_command(cmd.to_dict())
+            state = self._sim.get_state()
+            self._ts.update_from_pi(state)
+            return cmd.command_id
+
+        def send_focus(self, direction, steps):
+            from shared.commands.focus_command import FocusCommand
+            cmd = FocusCommand(direction=direction, steps=steps)
+            self._sim.send_command(cmd.to_dict())
+            state = self._sim.get_state()
+            self._ts.update_from_pi(state)
+            return cmd.command_id
+
+        def send_stop(self, emergency=False):
+            from shared.commands.stop_command import StopCommand
+            cmd = StopCommand(emergency=emergency)
+            self._sim.send_command(cmd.to_dict())
+            state = self._sim.get_state()
+            self._ts.update_from_pi(state)
+            return cmd.command_id
+
+        def send_status_request(self):
+            resp = self._sim.send_command(
+                {"command_type": "status_request"}
+            )
+            return True
+
+    sim_sender = SimSender(sender, sim, telescope_state)
+
+    # Inject the sim sender into tracking and focus
+    tracking._sender = sim_sender
+    focus._sender = sim_sender
+
+    interface._sender = sim_sender
+    interface.run()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Telescope Host Controller")
+    parser.add_argument("--host", default=SERVER_HOST, help="Bind address")
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_PORT, help="Listen port"
+    )
+    parser.add_argument(
+        "--lat", type=float, default=DEFAULT_OBSERVER_LAT,
+        help="Observer latitude (deg)",
+    )
+    parser.add_argument(
+        "--lon", type=float, default=DEFAULT_OBSERVER_LON,
+        help="Observer longitude (deg)",
+    )
+    parser.add_argument(
+        "--elev", type=float, default=DEFAULT_OBSERVER_ELEV,
+        help="Observer elevation (m)",
+    )
+    parser.add_argument(
+        "--simulate", action="store_true",
+        help="Run in simulation mode without Pi",
+    )
+    args = parser.parse_args()
+    run(args.host, args.port, args.lat, args.lon, args.elev, args.simulate)
+
+
+if __name__ == "__main__":
+    main()

--- a/host/simulation/simulator.py
+++ b/host/simulation/simulator.py
@@ -1,1 +1,152 @@
-# Simulated telescope for testing algorithms without Pi
+import queue
+import threading
+import time
+from typing import Optional
+
+from shared.commands.focus_command import FocusCommand, FOCUS_IN, FOCUS_OUT
+from shared.commands.move_command import MoveCommand
+from shared.commands.stop_command import StopCommand
+from shared.enums.command_types import CommandType
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.utils.logger import get_logger
+
+logger = get_logger("simulator")
+
+
+class TelescopeSimulator:
+    """In-process mock Pi for testing without TCP or real hardware."""
+
+    def __init__(self, slew_speed_deg_per_s: float = 5.0) -> None:
+        self._slew_speed = slew_speed_deg_per_s
+        self._lock = threading.Lock()
+        self._current_alt = 0.0
+        self._current_az = 0.0
+        self._target_alt: Optional[float] = None
+        self._target_az: Optional[float] = None
+        self._status = StatusCode.IDLE
+        self._focus_position = 5000
+        self._is_tracking = False
+        self._state_queue: "queue.Queue[TelescopeState]" = queue.Queue()
+        self._slew_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def send_command(self, data: dict) -> dict:
+        cmd_type = data.get("command_type")
+        cmd_id = data.get("command_id", "sim")
+
+        if cmd_type == CommandType.MOVE:
+            cmd = MoveCommand.from_dict(data)
+            self._start_slew(cmd)
+            return {"message_type": "ack", "command_id": cmd_id}
+
+        elif cmd_type == CommandType.FOCUS:
+            cmd = FocusCommand.from_dict(data)
+            self._execute_focus(cmd)
+            return {"message_type": "ack", "command_id": cmd_id}
+
+        elif cmd_type == CommandType.STOP:
+            cmd = StopCommand.from_dict(data)
+            self._execute_stop(cmd)
+            return {"message_type": "ack", "command_id": cmd_id}
+
+        elif cmd_type == CommandType.STATUS_REQUEST:
+            return self._build_state_report()
+
+        return {
+            "message_type": "error",
+            "command_id": cmd_id,
+            "error": "Unknown command: %s" % cmd_type,
+        }
+
+    def get_state(self) -> TelescopeState:
+        with self._lock:
+            return TelescopeState(
+                current_alt_deg=self._current_alt,
+                current_az_deg=self._current_az,
+                status=self._status,
+                target_alt_deg=self._target_alt,
+                target_az_deg=self._target_az,
+                focus_position=self._focus_position,
+                is_tracking=self._is_tracking,
+            )
+
+    def get_state_queue(self) -> "queue.Queue[TelescopeState]":
+        return self._state_queue
+
+    def _start_slew(self, cmd: MoveCommand) -> None:
+        self._stop_event.set()
+        if self._slew_thread is not None and self._slew_thread.is_alive():
+            self._slew_thread.join(timeout=1.0)
+
+        with self._lock:
+            self._target_alt = cmd.target_alt_deg
+            self._target_az = cmd.target_az_deg
+            self._status = StatusCode.MOVING
+
+        self._stop_event = threading.Event()
+        self._slew_thread = threading.Thread(
+            target=self._slew_loop,
+            args=(cmd.target_alt_deg, cmd.target_az_deg, cmd.speed),
+            daemon=True,
+        )
+        self._slew_thread.start()
+
+    def _slew_loop(
+        self, target_alt: float, target_az: float, speed: float
+    ) -> None:
+        rate = self._slew_speed * speed
+        dt = 0.05  # 20 Hz update
+
+        while not self._stop_event.is_set():
+            with self._lock:
+                d_alt = target_alt - self._current_alt
+                d_az = target_az - self._current_az
+                if d_az > 180.0:
+                    d_az -= 360.0
+                elif d_az < -180.0:
+                    d_az += 360.0
+
+                dist = (d_alt ** 2 + d_az ** 2) ** 0.5
+                if dist < 0.01:
+                    self._current_alt = target_alt
+                    self._current_az = target_az
+                    self._status = StatusCode.IDLE
+                    self._target_alt = None
+                    self._target_az = None
+                    state = self.get_state()
+                    self._state_queue.put(state)
+                    return
+
+                step = min(rate * dt, dist)
+                if dist > 0:
+                    self._current_alt += d_alt / dist * step
+                    self._current_az += d_az / dist * step
+
+            state = self.get_state()
+            self._state_queue.put(state)
+            self._stop_event.wait(timeout=dt)
+
+    def _execute_focus(self, cmd: FocusCommand) -> None:
+        with self._lock:
+            if cmd.direction == FOCUS_IN:
+                self._focus_position = max(0, self._focus_position - cmd.steps)
+            elif cmd.direction == FOCUS_OUT:
+                self._focus_position = min(10000, self._focus_position + cmd.steps)
+        logger.debug("Focus %s %d -> pos=%d", cmd.direction, cmd.steps, self._focus_position)
+
+    def _execute_stop(self, cmd: StopCommand) -> None:
+        self._stop_event.set()
+        with self._lock:
+            self._status = (
+                StatusCode.EMERGENCY_STOP if cmd.emergency else StatusCode.IDLE
+            )
+            self._target_alt = None
+            self._target_az = None
+            self._is_tracking = False
+
+    def _build_state_report(self) -> dict:
+        state = self.get_state()
+        data = state.to_dict()
+        data["message_type"] = "state_report"
+        return data

--- a/host/simulation/test_data.py
+++ b/host/simulation/test_data.py
@@ -1,1 +1,58 @@
-# Sample target positions, camera frames, or command sequences
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+
+# Sample named targets with approximate coordinates
+SAMPLE_TARGETS = [
+    {"name": "Polaris", "ra": 37.95, "dec": 89.26, "alt": 37.4, "az": 0.1},
+    {"name": "Sirius", "ra": 101.29, "dec": -16.72, "alt": 25.0, "az": 180.0},
+    {"name": "Vega", "ra": 279.23, "dec": 38.78, "alt": 60.0, "az": 270.0},
+    {"name": "Mars", "ra": 45.0, "dec": 20.0, "alt": 45.0, "az": 120.0},
+    {"name": "Jupiter", "ra": 30.0, "dec": -5.0, "alt": 35.0, "az": 200.0},
+]
+
+# A slew sequence for testing movement
+SLEW_SEQUENCE = [
+    {"alt": 45.0, "az": 0.0, "speed": 0.5},
+    {"alt": 45.0, "az": 90.0, "speed": 0.8},
+    {"alt": 60.0, "az": 90.0, "speed": 0.3},
+    {"alt": 60.0, "az": 180.0, "speed": 1.0},
+    {"alt": 30.0, "az": 270.0, "speed": 0.5},
+]
+
+
+def make_idle_state(
+    alt: float = 0.0, az: float = 0.0
+) -> TelescopeState:
+    return TelescopeState(
+        current_alt_deg=alt,
+        current_az_deg=az,
+        status=StatusCode.IDLE,
+    )
+
+
+def make_moving_state(
+    current_alt: float = 0.0,
+    current_az: float = 0.0,
+    target_alt: float = 45.0,
+    target_az: float = 90.0,
+) -> TelescopeState:
+    return TelescopeState(
+        current_alt_deg=current_alt,
+        current_az_deg=current_az,
+        status=StatusCode.MOVING,
+        target_alt_deg=target_alt,
+        target_az_deg=target_az,
+    )
+
+
+def make_error_state(
+    error_codes: list = None,
+) -> TelescopeState:
+    if error_codes is None:
+        error_codes = [10]  # MOTOR_STALL
+    return TelescopeState(
+        current_alt_deg=0.0,
+        current_az_deg=0.0,
+        status=StatusCode.ERROR,
+        error_codes=error_codes,
+    )

--- a/host/state/session_logs.py
+++ b/host/state/session_logs.py
@@ -1,1 +1,68 @@
-# Keeps runtime logs of commands, positions, and errors
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, List, Optional
+
+from host.utils.logger import get_logger
+
+logger = get_logger("session_logs")
+
+
+class LogEntry:
+    """A single log entry with category, data, and timestamp."""
+
+    def __init__(self, category: str, data: Dict) -> None:
+        self.category = category
+        self.data = data
+        self.timestamp = time.time()
+
+    def __repr__(self) -> str:
+        return "LogEntry(%s, %s)" % (self.category, self.data)
+
+
+class SessionLog:
+    """Thread-safe circular buffer of log entries."""
+
+    def __init__(self, max_entries: int = 1000) -> None:
+        self._lock = threading.Lock()
+        self._entries: Deque[LogEntry] = deque(maxlen=max_entries)
+        self._max_entries = max_entries
+
+    def log_command(self, command_type: str, details: Dict) -> None:
+        entry = LogEntry("command", {"type": command_type, **details})
+        with self._lock:
+            self._entries.append(entry)
+        logger.debug("Logged command: %s", command_type)
+
+    def log_state(self, state_data: Dict) -> None:
+        entry = LogEntry("state", state_data)
+        with self._lock:
+            self._entries.append(entry)
+
+    def log_error(self, error_msg: str, details: Optional[Dict] = None) -> None:
+        data = {"error": error_msg}
+        if details:
+            data.update(details)
+        entry = LogEntry("error", data)
+        with self._lock:
+            self._entries.append(entry)
+        logger.warning("Logged error: %s", error_msg)
+
+    def get_recent(self, count: int = 10) -> List[LogEntry]:
+        with self._lock:
+            items = list(self._entries)
+        return items[-count:]
+
+    def get_by_category(self, category: str, count: int = 10) -> List[LogEntry]:
+        with self._lock:
+            items = list(self._entries)
+        filtered = [e for e in items if e.category == category]
+        return filtered[-count:]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)

--- a/host/state/telescope_state.py
+++ b/host/state/telescope_state.py
@@ -1,1 +1,70 @@
-# Maintains full state of telescope (position, focus, errors)
+import threading
+import time
+from typing import Dict, Optional
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.utils.logger import get_logger
+
+logger = get_logger("telescope_state")
+
+
+class HostTelescopeState:
+    """Thread-safe store of the latest telescope state received from Pi."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: Optional[TelescopeState] = None
+        self._last_update: float = 0.0
+        self._tracking_target: Optional[str] = None
+
+    def update_from_pi(self, state: TelescopeState) -> None:
+        with self._lock:
+            self._state = state
+            self._last_update = time.monotonic()
+        logger.debug(
+            "State updated: alt=%.2f az=%.2f status=%s",
+            state.current_alt_deg,
+            state.current_az_deg,
+            state.status,
+        )
+
+    def get_latest(self) -> Optional[TelescopeState]:
+        with self._lock:
+            return self._state
+
+    def get_position(self) -> Optional[tuple]:
+        with self._lock:
+            if self._state is None:
+                return None
+            return (self._state.current_alt_deg, self._state.current_az_deg)
+
+    def get_status(self) -> str:
+        with self._lock:
+            if self._state is None:
+                return StatusCode.IDLE
+            return self._state.status
+
+    def seconds_since_update(self) -> float:
+        with self._lock:
+            if self._last_update == 0.0:
+                return float("inf")
+            return time.monotonic() - self._last_update
+
+    def set_tracking_target(self, name: str) -> None:
+        with self._lock:
+            self._tracking_target = name
+        logger.info("Tracking target set: %s", name)
+
+    def clear_tracking_target(self) -> None:
+        with self._lock:
+            self._tracking_target = None
+        logger.info("Tracking target cleared")
+
+    def get_tracking_target(self) -> Optional[str]:
+        with self._lock:
+            return self._tracking_target
+
+    def has_state(self) -> bool:
+        with self._lock:
+            return self._state is not None

--- a/host/ui/display.py
+++ b/host/ui/display.py
@@ -1,1 +1,66 @@
-# Functions for updating telescope state, logs, and status on the UI
+from typing import Dict, List, Optional
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.config.ui_params import STATUS_LINE_WIDTH
+from host.state.session_logs import LogEntry
+
+
+def format_state(state: Optional[TelescopeState]) -> str:
+    if state is None:
+        return "No state received from Pi yet."
+
+    lines = [
+        "=" * STATUS_LINE_WIDTH,
+        "  Position:  alt=%.4f  az=%.4f" % (
+            state.current_alt_deg, state.current_az_deg,
+        ),
+    ]
+
+    if state.target_alt_deg is not None and state.target_az_deg is not None:
+        lines.append(
+            "  Target:    alt=%.4f  az=%.4f" % (
+                state.target_alt_deg, state.target_az_deg,
+            )
+        )
+
+    status_str = state.status.value if hasattr(state.status, "value") else str(state.status)
+    lines.append("  Status:    %s" % status_str)
+
+    if state.focus_position is not None:
+        lines.append("  Focus:     %d" % state.focus_position)
+
+    if state.is_tracking:
+        lines.append("  Tracking:  YES")
+
+    if state.error_codes:
+        lines.append("  Errors:    %s" % state.error_codes)
+
+    lines.append("=" * STATUS_LINE_WIDTH)
+    return "\n".join(lines)
+
+
+def format_tracking_info(info: Dict) -> str:
+    if not info.get("tracking"):
+        return "Not tracking"
+
+    return "Tracking %s | target alt=%.2f az=%.2f | error=%.4f deg | %s" % (
+        info.get("target", "?"),
+        info.get("target_alt", 0.0),
+        info.get("target_az", 0.0),
+        info.get("error_deg", 0.0),
+        "OK" if info.get("within_tolerance") else "CORRECTING",
+    )
+
+
+def format_log_entries(entries: List[LogEntry], count: int = 10) -> str:
+    recent = entries[-count:]
+    if not recent:
+        return "No log entries."
+
+    lines = []
+    for entry in recent:
+        import time
+        ts = time.strftime("%H:%M:%S", time.localtime(entry.timestamp))
+        lines.append("[%s] %s: %s" % (ts, entry.category, entry.data))
+    return "\n".join(lines)

--- a/host/ui/host_interface.py
+++ b/host/ui/host_interface.py
@@ -1,1 +1,169 @@
-# Main UI logic, handles manual/auto mode toggling
+import sys
+from typing import Optional
+
+from host.comms.sender import Sender
+from host.config.ui_params import PROMPT_STRING
+from host.control.focus_controller import FocusController
+from host.control.tracking_controller import TrackingController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from host.ui.display import format_log_entries, format_state, format_tracking_info
+from host.utils.logger import get_logger
+
+logger = get_logger("interface")
+
+HELP_TEXT = """Commands:
+  move <alt> <az> [speed]  - Slew to alt/az (speed 0.0-1.0, default 0.5)
+  focus <in|out> <steps>   - Move focus motor
+  stop [emergency]         - Stop movement (add 'emergency' for e-stop)
+  track <name>             - Track a celestial object by name
+  track stop               - Stop tracking
+  autofocus                - Run autofocus routine
+  status                   - Show telescope state
+  tracking                 - Show tracking info
+  log [count]              - Show recent log entries
+  help                     - Show this help
+  quit                     - Exit"""
+
+
+class HostInterface:
+    """CLI interface for the telescope operator."""
+
+    def __init__(
+        self,
+        sender: Sender,
+        tracking: TrackingController,
+        focus: FocusController,
+        telescope_state: HostTelescopeState,
+        session_log: SessionLog,
+    ) -> None:
+        self._sender = sender
+        self._tracking = tracking
+        self._focus = focus
+        self._state = telescope_state
+        self._log = session_log
+        self._running = False
+
+    def run(self) -> None:
+        self._running = True
+        print(HELP_TEXT)
+
+        while self._running:
+            try:
+                line = input(PROMPT_STRING).strip()
+            except (EOFError, KeyboardInterrupt):
+                self._running = False
+                break
+
+            if not line:
+                continue
+
+            try:
+                self._dispatch(line)
+            except Exception as e:
+                print("Error: %s" % e)
+                logger.error("Command error: %s", e)
+
+    def stop(self) -> None:
+        self._running = False
+
+    def _dispatch(self, line: str) -> None:
+        parts = line.split()
+        cmd = parts[0].lower()
+        args = parts[1:]
+
+        if cmd == "move":
+            self._cmd_move(args)
+        elif cmd == "focus":
+            self._cmd_focus(args)
+        elif cmd == "stop":
+            self._cmd_stop(args)
+        elif cmd == "track":
+            self._cmd_track(args)
+        elif cmd == "autofocus":
+            self._cmd_autofocus()
+        elif cmd == "status":
+            self._cmd_status()
+        elif cmd == "tracking":
+            self._cmd_tracking()
+        elif cmd == "log":
+            self._cmd_log(args)
+        elif cmd == "help":
+            print(HELP_TEXT)
+        elif cmd == "quit":
+            self._running = False
+        else:
+            print("Unknown command: %s (type 'help' for commands)" % cmd)
+
+    def _cmd_move(self, args: list) -> None:
+        if len(args) < 2:
+            print("Usage: move <alt> <az> [speed]")
+            return
+        alt = float(args[0])
+        az = float(args[1])
+        speed = float(args[2]) if len(args) > 2 else 0.5
+        cmd_id = self._sender.send_move(alt, az, speed)
+        if cmd_id:
+            print("Move command sent (id=%s)" % cmd_id)
+        else:
+            print("Failed to send move command")
+
+    def _cmd_focus(self, args: list) -> None:
+        if len(args) < 2:
+            print("Usage: focus <in|out> <steps>")
+            return
+        direction = args[0].lower()
+        if direction not in ("in", "out"):
+            print("Direction must be 'in' or 'out'")
+            return
+        steps = int(args[1])
+        cmd_id = self._sender.send_focus(direction, steps)
+        if cmd_id:
+            print("Focus command sent (id=%s)" % cmd_id)
+        else:
+            print("Failed to send focus command")
+
+    def _cmd_stop(self, args: list) -> None:
+        emergency = len(args) > 0 and args[0].lower() == "emergency"
+        cmd_id = self._sender.send_stop(emergency=emergency)
+        if cmd_id:
+            label = "Emergency stop" if emergency else "Stop"
+            print("%s sent (id=%s)" % (label, cmd_id))
+        else:
+            print("Failed to send stop command")
+
+    def _cmd_track(self, args: list) -> None:
+        if not args:
+            print("Usage: track <name> | track stop")
+            return
+        if args[0].lower() == "stop":
+            self._tracking.stop_tracking()
+            print("Tracking stopped")
+        else:
+            name = " ".join(args)
+            ok = self._tracking.start_tracking(name)
+            if ok:
+                print("Now tracking: %s" % name)
+            else:
+                print("Failed to start tracking '%s'" % name)
+
+    def _cmd_autofocus(self) -> None:
+        print("Running autofocus...")
+        improved = self._focus.run_autofocus()
+        if improved:
+            print("Autofocus improved focus position")
+        else:
+            print("Autofocus found no improvement")
+
+    def _cmd_status(self) -> None:
+        state = self._state.get_latest()
+        print(format_state(state))
+
+    def _cmd_tracking(self) -> None:
+        info = self._tracking.get_tracking_info()
+        print(format_tracking_info(info))
+
+    def _cmd_log(self, args: list) -> None:
+        count = int(args[0]) if args else 10
+        entries = self._log.get_recent(count)
+        print(format_log_entries(entries, count))

--- a/host/utils/logger.py
+++ b/host/utils/logger.py
@@ -1,1 +1,39 @@
-# General logging utilities
+import logging
+from typing import Any, Dict
+
+from shared.errors.error_codes import get_error_description
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger("host.%s" % name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "[HOST] %(asctime)s %(name)s %(levelname)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def log_command_sent(
+    logger: logging.Logger, command_type: str, details: Dict[str, Any]
+) -> None:
+    parts = ["%s=%s" % (k, v) for k, v in details.items()]
+    logger.info("CMD_SENT %s | %s", command_type, " ".join(parts))
+
+
+def log_state_received(logger: logging.Logger, state: Dict[str, Any]) -> None:
+    logger.debug(
+        "STATE alt=%.2f az=%.2f status=%s",
+        state.get("current_alt_deg", 0.0),
+        state.get("current_az_deg", 0.0),
+        state.get("status", "unknown"),
+    )
+
+
+def log_error_code(logger: logging.Logger, code: int) -> None:
+    desc = get_error_description(code)
+    logger.error("ERROR %d: %s", code, desc)

--- a/host/utils/math_utils.py
+++ b/host/utils/math_utils.py
@@ -1,1 +1,65 @@
-# Helper functions for vector math, conversions, etc.
+import math
+
+
+def angular_distance(alt1: float, az1: float, alt2: float, az2: float) -> float:
+    """Compute angular distance between two alt/az positions using Vincenty formula."""
+    lat1 = math.radians(alt1)
+    lat2 = math.radians(alt2)
+    dlon = math.radians(az2 - az1)
+
+    sin_lat1 = math.sin(lat1)
+    cos_lat1 = math.cos(lat1)
+    sin_lat2 = math.sin(lat2)
+    cos_lat2 = math.cos(lat2)
+    sin_dlon = math.sin(dlon)
+    cos_dlon = math.cos(dlon)
+
+    num = math.sqrt(
+        (cos_lat2 * sin_dlon) ** 2
+        + (cos_lat1 * sin_lat2 - sin_lat1 * cos_lat2 * cos_dlon) ** 2
+    )
+    den = sin_lat1 * sin_lat2 + cos_lat1 * cos_lat2 * cos_dlon
+
+    return math.degrees(math.atan2(num, den))
+
+
+def normalize_angle(angle: float, min_val: float, max_val: float) -> float:
+    """Wrap angle to [min_val, max_val) range."""
+    span = max_val - min_val
+    if span <= 0:
+        return angle
+    result = angle
+    while result >= max_val:
+        result -= span
+    while result < min_val:
+        result += span
+    return result
+
+
+def clamp(value: float, low: float, high: float) -> float:
+    """Clamp value to [low, high] range."""
+    return max(low, min(high, value))
+
+
+def alt_az_delta(
+    current_alt: float, current_az: float,
+    target_alt: float, target_az: float,
+) -> tuple:
+    """Compute (delta_alt, delta_az) with shortest-path azimuth wrapping."""
+    d_alt = target_alt - current_alt
+    d_az = target_az - current_az
+    if d_az > 180.0:
+        d_az -= 360.0
+    elif d_az < -180.0:
+        d_az += 360.0
+    return (d_alt, d_az)
+
+
+def degrees_to_arcsec(deg: float) -> float:
+    """Convert degrees to arcseconds."""
+    return deg * 3600.0
+
+
+def arcsec_to_degrees(arcsec: float) -> float:
+    """Convert arcseconds to degrees."""
+    return arcsec / 3600.0

--- a/host/utils/threading_utils.py
+++ b/host/utils/threading_utils.py
@@ -1,1 +1,90 @@
-# Utilities to manage threads or async tasks
+import threading
+import time
+from typing import Callable, Optional
+
+
+class StoppableThread:
+    """Thread wrapper with a stop event for clean shutdown."""
+
+    def __init__(
+        self,
+        target: Callable[..., None],
+        name: Optional[str] = None,
+        daemon: bool = True,
+    ) -> None:
+        self._target = target
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._name = name
+        self._daemon = daemon
+
+    @property
+    def stop_event(self) -> threading.Event:
+        return self._stop_event
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._target,
+            args=(self._stop_event,),
+            name=self._name,
+            daemon=self._daemon,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+
+class PeriodicTask:
+    """Runs a callable at a fixed rate in a background thread."""
+
+    def __init__(
+        self,
+        target: Callable[[], None],
+        hz: float,
+        name: Optional[str] = None,
+    ) -> None:
+        self._target = target
+        self._interval = 1.0 / hz if hz > 0 else 1.0
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._name = name
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=self._name,
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            start = time.monotonic()
+            try:
+                self._target()
+            except Exception:
+                pass
+            elapsed = time.monotonic() - start
+            sleep_time = self._interval - elapsed
+            if sleep_time > 0:
+                self._stop_event.wait(timeout=sleep_time)

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,29 +1,28 @@
 # Scratchpad
 
 ## Current Task
-None — between tasks. Progress tracking system just set up.
+host/ layer implementation complete — ready for PR.
 
 ## Status
 - [x] Infrastructure: CLAUDE.md, MEMORY.md, scratchpad.md, commands, agents
 - [x] shared/ protocol layer (11 source files, 69 tests) — PR #6 merged
 - [x] pi/ hardware control layer (17 source files, 86 tests) — PR #7 merged
 - [x] Progress tracking system (docs/PROGRESS.md, task board, /save command)
-- [ ] host/ layer implementation (~18 stub files remaining)
+- [x] host/ layer implementation (18 source files, 148 tests) — on feat/host-control-layer
 - [ ] Integration testing
 - [ ] Documentation updates
 
 ## Next Steps
-1. host/comms/ — TCP server + message handling (server-side mirror of pi/comms/)
-2. host/state/ — Telescope state tracking, session logging
-3. host/control/ — Tracking loop, error correction, focus
-4. host/config/, host/utils/, host/ui/, host/simulation/, host/main.py
-5. Integration testing and documentation
+1. Create PR for feat/host-control-layer → main
+2. Integration testing — end-to-end host↔pi communication
+3. Update README.md (remove Java references)
+4. Fill docs/architecture.md
 
 ## Blockers
 None currently.
 
 ## Notes
-- 163 tests passing (86 pi/ + 69 shared/ + 8 host/)
+- 303 tests passing (86 pi/ + 69 shared/ + 148 host/)
 - Python 3.9 compat: use `Optional[X]`, `List[X]`, `Dict[K,V]`
-- README.md still references Java — needs updating
-- docs/PROGRESS.md is now the primary session-persistent progress tracker
+- Host is TCP server (Pi connects as client)
+- Simulation mode: `python3 -m host.main --simulate`

--- a/tests/host/test_constants.py
+++ b/tests/host/test_constants.py
@@ -1,0 +1,40 @@
+import pytest
+
+from host.config.constants import (
+    COMMAND_ACK_TIMEOUT_S,
+    DEFAULT_OBSERVER_ELEV,
+    DEFAULT_OBSERVER_LAT,
+    DEFAULT_OBSERVER_LON,
+    FOCUS_SEARCH_STEPS,
+    MAX_COMMAND_RETRIES,
+    PI_HEARTBEAT_TIMEOUT_S,
+    PID_KD,
+    PID_KI,
+    PID_KP,
+    SERVER_HOST,
+    SERVER_PORT,
+    TRACKING_LOOP_HZ,
+    TRACKING_TOLERANCE_DEG,
+)
+
+
+class TestConstants:
+    def test_server_port_in_valid_range(self):
+        assert 1024 <= SERVER_PORT <= 65535
+
+    def test_tracking_hz_positive(self):
+        assert TRACKING_LOOP_HZ > 0
+
+    def test_pid_gains_non_negative(self):
+        assert PID_KP >= 0
+        assert PID_KI >= 0
+        assert PID_KD >= 0
+
+    def test_focus_search_steps_descending(self):
+        for i in range(len(FOCUS_SEARCH_STEPS) - 1):
+            assert FOCUS_SEARCH_STEPS[i] > FOCUS_SEARCH_STEPS[i + 1]
+
+    def test_observer_location_valid(self):
+        assert -90 <= DEFAULT_OBSERVER_LAT <= 90
+        assert -180 <= DEFAULT_OBSERVER_LON <= 180
+        assert DEFAULT_OBSERVER_ELEV >= 0

--- a/tests/host/test_display.py
+++ b/tests/host/test_display.py
@@ -1,0 +1,78 @@
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.state.session_logs import LogEntry, SessionLog
+from host.ui.display import format_log_entries, format_state, format_tracking_info
+
+
+class TestFormatState:
+    def test_none_state(self):
+        result = format_state(None)
+        assert "No state" in result
+
+    def test_basic_state(self):
+        state = TelescopeState(
+            current_alt_deg=45.123,
+            current_az_deg=90.456,
+            status=StatusCode.IDLE,
+        )
+        result = format_state(state)
+        assert "45.1230" in result
+        assert "90.4560" in result
+        assert "idle" in result
+
+    def test_state_with_target(self):
+        state = TelescopeState(
+            current_alt_deg=10.0,
+            current_az_deg=20.0,
+            status=StatusCode.MOVING,
+            target_alt_deg=45.0,
+            target_az_deg=90.0,
+        )
+        result = format_state(state)
+        assert "Target" in result
+
+    def test_state_with_errors(self):
+        state = TelescopeState(
+            current_alt_deg=0.0,
+            current_az_deg=0.0,
+            status=StatusCode.ERROR,
+            error_codes=[10, 20],
+        )
+        result = format_state(state)
+        assert "Errors" in result
+
+
+class TestFormatTrackingInfo:
+    def test_not_tracking(self):
+        result = format_tracking_info({"tracking": False})
+        assert "Not tracking" in result
+
+    def test_tracking_active(self):
+        info = {
+            "tracking": True,
+            "target": "Mars",
+            "target_alt": 45.0,
+            "target_az": 120.0,
+            "error_deg": 0.5,
+            "within_tolerance": False,
+        }
+        result = format_tracking_info(info)
+        assert "Mars" in result
+        assert "CORRECTING" in result
+
+
+class TestFormatLogEntries:
+    def test_empty_log(self):
+        result = format_log_entries([])
+        assert "No log" in result
+
+    def test_with_entries(self):
+        entries = [
+            LogEntry("command", {"type": "move"}),
+            LogEntry("error", {"msg": "fail"}),
+        ]
+        result = format_log_entries(entries)
+        assert "command" in result
+        assert "error" in result

--- a/tests/host/test_error_correction.py
+++ b/tests/host/test_error_correction.py
@@ -1,0 +1,55 @@
+import time
+
+import pytest
+
+from host.control.error_correction import PIDController
+
+
+class TestPIDController:
+    def test_proportional_only(self):
+        pid = PIDController(kp=2.0, ki=0.0, kd=0.0, output_min=-10.0, output_max=10.0)
+        output = pid.compute(5.0)
+        assert output == pytest.approx(10.0)
+
+    def test_proportional_small(self):
+        pid = PIDController(kp=0.5, ki=0.0, kd=0.0, output_min=-10.0, output_max=10.0)
+        output = pid.compute(3.0)
+        assert output == pytest.approx(1.5)
+
+    def test_integral_accumulates(self):
+        pid = PIDController(kp=0.0, ki=1.0, kd=0.0, output_min=-100.0, output_max=100.0)
+        pid.compute(1.0)
+        time.sleep(0.05)
+        output = pid.compute(1.0)
+        assert output > 0
+
+    def test_derivative_responds_to_change(self):
+        pid = PIDController(kp=0.0, ki=0.0, kd=1.0, output_min=-100.0, output_max=100.0)
+        pid.compute(0.0)
+        time.sleep(0.05)
+        output = pid.compute(10.0)
+        assert output > 0
+
+    def test_clamping_max(self):
+        pid = PIDController(kp=100.0, ki=0.0, kd=0.0, output_min=0.0, output_max=1.0)
+        output = pid.compute(5.0)
+        assert output == pytest.approx(1.0)
+
+    def test_clamping_min(self):
+        pid = PIDController(kp=100.0, ki=0.0, kd=0.0, output_min=0.0, output_max=1.0)
+        output = pid.compute(-5.0)
+        assert output == pytest.approx(0.0)
+
+    def test_reset_clears_state(self):
+        pid = PIDController(kp=0.0, ki=1.0, kd=0.0, output_min=-100.0, output_max=100.0)
+        pid.compute(10.0)
+        time.sleep(0.05)
+        pid.compute(10.0)
+        pid.reset()
+        output = pid.compute(0.0)
+        assert output == pytest.approx(0.0)
+
+    def test_zero_error_gives_zero(self):
+        pid = PIDController(kp=1.0, ki=0.0, kd=0.0, output_min=-10.0, output_max=10.0)
+        output = pid.compute(0.0)
+        assert output == pytest.approx(0.0)

--- a/tests/host/test_focus.py
+++ b/tests/host/test_focus.py
@@ -1,0 +1,78 @@
+import queue
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.comms.sender import Sender
+from host.control.focus_controller import FocusController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+
+
+@pytest.fixture
+def setup():
+    sl = SessionLog()
+    rq = queue.Queue()
+    sender = MagicMock(spec=Sender)
+    sender.send_focus.return_value = "focus-123"
+
+    ts = HostTelescopeState()
+    ts.update_from_pi(TelescopeState(
+        current_alt_deg=0.0,
+        current_az_deg=0.0,
+        status=StatusCode.IDLE,
+        focus_position=5000,
+    ))
+
+    fc = FocusController(sender=sender, telescope_state=ts, session_log=sl)
+    return fc, sender, ts, sl
+
+
+class TestFocusController:
+    def test_autofocus_calls_send_focus(self, setup):
+        fc, sender, ts, sl = setup
+        fc.run_autofocus(step_sizes=[100])
+        assert sender.send_focus.call_count > 0
+
+    def test_autofocus_not_running_initially(self, setup):
+        fc, sender, ts, sl = setup
+        assert not fc.is_running
+
+    def test_autofocus_not_running_after_complete(self, setup):
+        fc, sender, ts, sl = setup
+        fc.run_autofocus(step_sizes=[100])
+        assert not fc.is_running
+
+    def test_autofocus_with_no_state(self):
+        sl = SessionLog()
+        rq = queue.Queue()
+        sender = MagicMock(spec=Sender)
+        sender.send_focus.return_value = "f-1"
+        ts = HostTelescopeState()
+        fc = FocusController(sender=sender, telescope_state=ts, session_log=sl)
+        result = fc.run_autofocus(step_sizes=[50])
+        assert not result
+
+    def test_autofocus_multiple_steps(self, setup):
+        fc, sender, ts, sl = setup
+        fc.run_autofocus(step_sizes=[100, 50])
+        assert sender.send_focus.call_count >= 2
+
+    def test_autofocus_logs_start_and_done(self, setup):
+        fc, sender, ts, sl = setup
+        fc.run_autofocus(step_sizes=[100])
+        categories = [e.data.get("type") for e in sl.get_by_category("command")]
+        assert "autofocus_start" in categories
+        assert "autofocus_done" in categories
+
+    def test_default_step_sizes_used(self, setup):
+        fc, sender, ts, sl = setup
+        fc.run_autofocus()
+        assert sender.send_focus.call_count > 0
+
+    def test_autofocus_returns_bool(self, setup):
+        fc, sender, ts, sl = setup
+        result = fc.run_autofocus(step_sizes=[100])
+        assert isinstance(result, bool)

--- a/tests/host/test_host_interface.py
+++ b/tests/host/test_host_interface.py
@@ -1,0 +1,92 @@
+import queue
+from unittest.mock import MagicMock, patch
+from io import StringIO
+
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.comms.sender import Sender
+from host.control.focus_controller import FocusController
+from host.control.tracking_controller import TrackingController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from host.ui.host_interface import HostInterface
+
+
+@pytest.fixture
+def setup():
+    sender = MagicMock(spec=Sender)
+    sender.send_move.return_value = "cmd-1"
+    sender.send_focus.return_value = "cmd-2"
+    sender.send_stop.return_value = "cmd-3"
+
+    tracking = MagicMock(spec=TrackingController)
+    tracking.is_tracking = False
+    tracking.start_tracking.return_value = True
+    tracking.get_tracking_info.return_value = {"tracking": False}
+
+    focus = MagicMock(spec=FocusController)
+    focus.run_autofocus.return_value = True
+
+    ts = HostTelescopeState()
+    ts.update_from_pi(TelescopeState(
+        current_alt_deg=0.0, current_az_deg=0.0, status=StatusCode.IDLE,
+    ))
+    sl = SessionLog()
+
+    interface = HostInterface(sender, tracking, focus, ts, sl)
+    return interface, sender, tracking, focus
+
+
+class TestHostInterface:
+    def test_dispatch_move(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("move 45.0 90.0 0.5")
+        sender.send_move.assert_called_once_with(45.0, 90.0, 0.5)
+
+    def test_dispatch_focus(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("focus in 100")
+        sender.send_focus.assert_called_once_with("in", 100)
+
+    def test_dispatch_stop(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("stop")
+        sender.send_stop.assert_called_once_with(emergency=False)
+
+    def test_dispatch_stop_emergency(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("stop emergency")
+        sender.send_stop.assert_called_once_with(emergency=True)
+
+    def test_dispatch_track(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("track Mars")
+        tracking.start_tracking.assert_called_once_with("Mars")
+
+    def test_dispatch_track_stop(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("track stop")
+        tracking.stop_tracking.assert_called_once()
+
+    def test_dispatch_autofocus(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("autofocus")
+        focus.run_autofocus.assert_called_once()
+
+    def test_dispatch_quit(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("quit")
+        assert not interface._running
+
+    def test_dispatch_unknown_command(self, setup, capsys):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("xyzzy")
+        captured = capsys.readouterr()
+        assert "Unknown command" in captured.out
+
+    def test_move_default_speed(self, setup):
+        interface, sender, tracking, focus = setup
+        interface._dispatch("move 10.0 20.0")
+        sender.send_move.assert_called_once_with(10.0, 20.0, 0.5)

--- a/tests/host/test_logger.py
+++ b/tests/host/test_logger.py
@@ -1,0 +1,47 @@
+import logging
+
+import pytest
+
+from host.utils.logger import get_logger, log_command_sent, log_error_code, log_state_received
+
+
+class TestGetLogger:
+    def test_returns_logger_with_host_prefix(self):
+        lgr = get_logger("test_mod")
+        assert lgr.name == "host.test_mod"
+
+    def test_logger_has_handler(self):
+        lgr = get_logger("handler_test")
+        assert len(lgr.handlers) >= 1
+
+    def test_no_duplicate_handlers(self):
+        lgr = get_logger("dup_test")
+        count_before = len(lgr.handlers)
+        lgr2 = get_logger("dup_test")
+        assert len(lgr2.handlers) == count_before
+
+    def test_formatter_includes_host_tag(self):
+        lgr = get_logger("fmt_test")
+        handler = lgr.handlers[0]
+        fmt = handler.formatter._fmt
+        assert "[HOST]" in fmt
+
+
+class TestLogHelpers:
+    def test_log_command_sent(self, caplog):
+        lgr = get_logger("cmd_test")
+        with caplog.at_level(logging.DEBUG, logger="host.cmd_test"):
+            log_command_sent(lgr, "move", {"alt": 45.0, "az": 90.0})
+        assert "CMD_SENT" in caplog.text
+
+    def test_log_state_received(self, caplog):
+        lgr = get_logger("state_test")
+        with caplog.at_level(logging.DEBUG, logger="host.state_test"):
+            log_state_received(lgr, {"current_alt_deg": 1.0, "current_az_deg": 2.0, "status": "idle"})
+        assert "STATE" in caplog.text
+
+    def test_log_error_code(self, caplog):
+        lgr = get_logger("err_test")
+        with caplog.at_level(logging.DEBUG, logger="host.err_test"):
+            log_error_code(lgr, 10)
+        assert "ERROR 10" in caplog.text

--- a/tests/host/test_main.py
+++ b/tests/host/test_main.py
@@ -1,0 +1,84 @@
+import socket
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from host.main import start_tcp_server, wait_for_pi, main
+
+
+class TestStartTCPServer:
+    def test_creates_listening_socket(self):
+        server = start_tcp_server("127.0.0.1", 0)
+        try:
+            addr = server.getsockname()
+            assert addr[0] == "127.0.0.1"
+            assert addr[1] > 0
+        finally:
+            server.close()
+
+    def test_accepts_connection(self):
+        server = start_tcp_server("127.0.0.1", 0)
+        port = server.getsockname()[1]
+        try:
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.connect(("127.0.0.1", port))
+            peer, addr = server.accept()
+            assert addr[0] == "127.0.0.1"
+            peer.close()
+            client.close()
+        finally:
+            server.close()
+
+
+class TestWaitForPi:
+    def test_returns_socket_on_connect(self):
+        server = start_tcp_server("127.0.0.1", 0)
+        port = server.getsockname()[1]
+        try:
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.connect(("127.0.0.1", port))
+            result = wait_for_pi(server)
+            assert result is not None
+            result.close()
+            client.close()
+        finally:
+            server.close()
+
+    def test_returns_none_on_shutdown(self):
+        import host.main as hm
+        old = hm._shutdown
+        hm._shutdown = True
+        server = start_tcp_server("127.0.0.1", 0)
+        try:
+            result = wait_for_pi(server)
+            assert result is None
+        finally:
+            server.close()
+            hm._shutdown = old
+
+
+class TestMainArgparse:
+    def test_argparse_defaults(self):
+        with patch.object(sys, "argv", ["host.main"]):
+            with patch("host.main.run") as mock_run:
+                main()
+                mock_run.assert_called_once()
+                args = mock_run.call_args
+                assert args[0][1] == 5050  # default port
+
+    def test_argparse_custom_port(self):
+        with patch.object(sys, "argv", ["host.main", "--port", "9999"]):
+            with patch("host.main.run") as mock_run:
+                main()
+                args = mock_run.call_args
+                assert args[0][1] == 9999
+
+    def test_argparse_simulate_flag(self):
+        with patch.object(sys, "argv", ["host.main", "--simulate"]):
+            with patch("host.main.run") as mock_run:
+                main()
+                mock_run.assert_called_once()
+                call_args = mock_run.call_args
+                # simulate is the 6th positional arg (index 5)
+                assert call_args[0][5] is True

--- a/tests/host/test_math_utils.py
+++ b/tests/host/test_math_utils.py
@@ -1,0 +1,80 @@
+import pytest
+
+from host.utils.math_utils import (
+    alt_az_delta,
+    angular_distance,
+    arcsec_to_degrees,
+    clamp,
+    degrees_to_arcsec,
+    normalize_angle,
+)
+
+
+class TestAngularDistance:
+    def test_same_point_is_zero(self):
+        assert angular_distance(45.0, 90.0, 45.0, 90.0) == pytest.approx(0.0, abs=1e-10)
+
+    def test_known_distance(self):
+        dist = angular_distance(0.0, 0.0, 0.0, 90.0)
+        assert dist == pytest.approx(90.0, abs=0.01)
+
+    def test_pole_to_pole(self):
+        dist = angular_distance(90.0, 0.0, -90.0, 0.0)
+        assert dist == pytest.approx(180.0, abs=0.01)
+
+    def test_symmetric(self):
+        d1 = angular_distance(10.0, 20.0, 30.0, 40.0)
+        d2 = angular_distance(30.0, 40.0, 10.0, 20.0)
+        assert d1 == pytest.approx(d2, abs=1e-10)
+
+
+class TestNormalizeAngle:
+    def test_within_range(self):
+        assert normalize_angle(45.0, 0.0, 360.0) == pytest.approx(45.0)
+
+    def test_wrap_above(self):
+        assert normalize_angle(370.0, 0.0, 360.0) == pytest.approx(10.0)
+
+    def test_wrap_below(self):
+        assert normalize_angle(-10.0, 0.0, 360.0) == pytest.approx(350.0)
+
+    def test_exact_max_wraps(self):
+        assert normalize_angle(360.0, 0.0, 360.0) == pytest.approx(0.0)
+
+
+class TestClamp:
+    def test_within(self):
+        assert clamp(5.0, 0.0, 10.0) == 5.0
+
+    def test_below(self):
+        assert clamp(-1.0, 0.0, 10.0) == 0.0
+
+    def test_above(self):
+        assert clamp(15.0, 0.0, 10.0) == 10.0
+
+
+class TestAltAzDelta:
+    def test_simple_delta(self):
+        d_alt, d_az = alt_az_delta(10.0, 20.0, 30.0, 40.0)
+        assert d_alt == pytest.approx(20.0)
+        assert d_az == pytest.approx(20.0)
+
+    def test_shortest_path_positive_wrap(self):
+        d_alt, d_az = alt_az_delta(0.0, 350.0, 0.0, 10.0)
+        assert d_az == pytest.approx(20.0)
+
+    def test_shortest_path_negative_wrap(self):
+        d_alt, d_az = alt_az_delta(0.0, 10.0, 0.0, 350.0)
+        assert d_az == pytest.approx(-20.0)
+
+
+class TestConversions:
+    def test_degrees_to_arcsec(self):
+        assert degrees_to_arcsec(1.0) == pytest.approx(3600.0)
+
+    def test_arcsec_to_degrees(self):
+        assert arcsec_to_degrees(3600.0) == pytest.approx(1.0)
+
+    def test_roundtrip(self):
+        val = 0.5
+        assert arcsec_to_degrees(degrees_to_arcsec(val)) == pytest.approx(val)

--- a/tests/host/test_receiver.py
+++ b/tests/host/test_receiver.py
@@ -1,0 +1,137 @@
+import queue
+import socket
+import struct
+import json
+import threading
+import time
+
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.comms.receiver import Receiver
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+
+
+def _make_socket_pair():
+    """Create a connected pair of sockets for testing."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("127.0.0.1", port))
+    peer, _ = server.accept()
+    server.close()
+    return client, peer
+
+
+def _send_raw(sock, data):
+    """Send a framed message."""
+    payload = json.dumps(data).encode("utf-8")
+    header = struct.pack("!I", len(payload))
+    sock.sendall(header + payload)
+
+
+@pytest.fixture
+def setup():
+    ts = HostTelescopeState()
+    sl = SessionLog()
+    rq = queue.Queue()
+    client, peer = _make_socket_pair()
+    client.settimeout(1.0)
+    receiver = Receiver(ts, sl, rq)
+    yield ts, sl, rq, client, peer, receiver
+    receiver.stop()
+    client.close()
+    peer.close()
+
+
+class TestReceiver:
+    def test_state_report_updates_telescope_state(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        state_data = TelescopeState(
+            current_alt_deg=45.0,
+            current_az_deg=90.0,
+            status=StatusCode.IDLE,
+        ).to_dict()
+        state_data["message_type"] = "state_report"
+        _send_raw(peer, state_data)
+
+        time.sleep(0.2)
+        assert ts.has_state()
+        pos = ts.get_position()
+        assert pos[0] == pytest.approx(45.0)
+
+    def test_ack_goes_to_response_queue(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        _send_raw(peer, {"message_type": "ack", "command_id": "abc123"})
+        time.sleep(0.2)
+        msg = rq.get(timeout=1.0)
+        assert msg["command_id"] == "abc123"
+
+    def test_error_goes_to_response_queue(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        _send_raw(peer, {"message_type": "error", "command_id": "x", "error": "bad"})
+        time.sleep(0.2)
+        msg = rq.get(timeout=1.0)
+        assert msg["message_type"] == "error"
+
+    def test_disconnect_stops_receiver(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+        time.sleep(0.1)
+
+        peer.close()
+        time.sleep(0.5)
+        assert not receiver.is_alive()
+
+    def test_stop_stops_cleanly(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+        assert receiver.is_alive()
+        receiver.stop()
+        assert not receiver.is_alive()
+
+    def test_bad_state_report_logged(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        _send_raw(peer, {"message_type": "state_report", "bad": "data"})
+        time.sleep(0.2)
+        assert not ts.has_state()
+
+    def test_unknown_message_type_ignored(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        _send_raw(peer, {"message_type": "weird", "data": 123})
+        time.sleep(0.2)
+        assert rq.empty()
+
+    def test_multiple_state_reports(self, setup):
+        ts, sl, rq, client, peer, receiver = setup
+        receiver.start(client)
+
+        for i in range(3):
+            state_data = TelescopeState(
+                current_alt_deg=float(i * 10),
+                current_az_deg=float(i * 20),
+                status=StatusCode.IDLE,
+            ).to_dict()
+            state_data["message_type"] = "state_report"
+            _send_raw(peer, state_data)
+
+        time.sleep(0.3)
+        pos = ts.get_position()
+        assert pos[0] == pytest.approx(20.0)
+        assert pos[1] == pytest.approx(40.0)

--- a/tests/host/test_sender.py
+++ b/tests/host/test_sender.py
@@ -1,0 +1,129 @@
+import json
+import queue
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from host.comms.sender import Sender
+from host.state.session_logs import SessionLog
+
+
+def _make_socket_pair():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("127.0.0.1", port))
+    peer, _ = server.accept()
+    server.close()
+    return client, peer
+
+
+def _recv_raw(sock):
+    """Receive a framed message."""
+    sock.settimeout(2.0)
+    header = b""
+    while len(header) < 4:
+        chunk = sock.recv(4 - len(header))
+        if not chunk:
+            return None
+        header += chunk
+    length = struct.unpack("!I", header)[0]
+    payload = b""
+    while len(payload) < length:
+        chunk = sock.recv(length - len(payload))
+        if not chunk:
+            return None
+        payload += chunk
+    return json.loads(payload.decode("utf-8"))
+
+
+@pytest.fixture
+def setup():
+    sl = SessionLog()
+    rq = queue.Queue()
+    sender = Sender(sl, rq)
+    client, peer = _make_socket_pair()
+    sender.set_socket(client)
+    yield sender, sl, rq, client, peer
+    client.close()
+    peer.close()
+
+
+class TestSender:
+    def test_send_move(self, setup):
+        sender, sl, rq, client, peer = setup
+        cmd_id = sender.send_move(45.0, 90.0, 0.5)
+        assert cmd_id is not None
+        msg = _recv_raw(peer)
+        assert msg["command_type"] == "move"
+        assert msg["target_alt_deg"] == 45.0
+
+    def test_send_focus(self, setup):
+        sender, sl, rq, client, peer = setup
+        cmd_id = sender.send_focus("in", 100)
+        assert cmd_id is not None
+        msg = _recv_raw(peer)
+        assert msg["command_type"] == "focus"
+        assert msg["direction"] == "in"
+        assert msg["steps"] == 100
+
+    def test_send_stop(self, setup):
+        sender, sl, rq, client, peer = setup
+        cmd_id = sender.send_stop(emergency=True)
+        assert cmd_id is not None
+        msg = _recv_raw(peer)
+        assert msg["command_type"] == "stop"
+        assert msg["emergency"] is True
+
+    def test_send_status_request(self, setup):
+        sender, sl, rq, client, peer = setup
+        ok = sender.send_status_request()
+        assert ok is True
+        msg = _recv_raw(peer)
+        assert msg["command_type"] == "status_request"
+
+    def test_send_without_socket_fails(self):
+        sl = SessionLog()
+        rq = queue.Queue()
+        sender = Sender(sl, rq)
+        cmd_id = sender.send_move(10.0, 20.0)
+        assert cmd_id is None
+
+    def test_send_invalid_command_rejected(self, setup):
+        sender, sl, rq, client, peer = setup
+        # Altitude out of range
+        cmd_id = sender.send_move(200.0, 90.0)
+        assert cmd_id is None
+
+    def test_session_log_records_command(self, setup):
+        sender, sl, rq, client, peer = setup
+        sender.send_move(45.0, 90.0)
+        entries = sl.get_by_category("command")
+        assert len(entries) == 1
+
+    def test_wait_for_ack_success(self, setup):
+        sender, sl, rq, client, peer = setup
+        cmd_id = sender.send_move(45.0, 90.0)
+        rq.put({"message_type": "ack", "command_id": cmd_id})
+        result = sender.wait_for_ack(cmd_id, timeout=1.0)
+        assert result is not None
+        assert result["command_id"] == cmd_id
+
+    def test_wait_for_ack_timeout(self, setup):
+        sender, sl, rq, client, peer = setup
+        result = sender.wait_for_ack("nonexistent", timeout=0.2)
+        assert result is None
+
+    def test_send_stop_non_emergency(self, setup):
+        sender, sl, rq, client, peer = setup
+        cmd_id = sender.send_stop(emergency=False)
+        assert cmd_id is not None
+        msg = _recv_raw(peer)
+        assert msg["emergency"] is False

--- a/tests/host/test_session_logs.py
+++ b/tests/host/test_session_logs.py
@@ -1,0 +1,69 @@
+import pytest
+
+from host.state.session_logs import LogEntry, SessionLog
+
+
+class TestLogEntry:
+    def test_has_timestamp(self):
+        entry = LogEntry("command", {"type": "move"})
+        assert entry.timestamp > 0
+
+    def test_stores_category_and_data(self):
+        entry = LogEntry("error", {"msg": "fail"})
+        assert entry.category == "error"
+        assert entry.data == {"msg": "fail"}
+
+
+class TestSessionLog:
+    def test_log_command(self):
+        log = SessionLog()
+        log.log_command("move", {"alt": 45.0})
+        assert len(log) == 1
+
+    def test_log_state(self):
+        log = SessionLog()
+        log.log_state({"alt": 10.0})
+        entries = log.get_recent(1)
+        assert entries[0].category == "state"
+
+    def test_log_error(self):
+        log = SessionLog()
+        log.log_error("test error")
+        entries = log.get_recent(1)
+        assert entries[0].category == "error"
+        assert entries[0].data["error"] == "test error"
+
+    def test_get_recent(self):
+        log = SessionLog()
+        for i in range(20):
+            log.log_command("cmd_%d" % i, {})
+        recent = log.get_recent(5)
+        assert len(recent) == 5
+
+    def test_get_by_category(self):
+        log = SessionLog()
+        log.log_command("move", {})
+        log.log_error("err")
+        log.log_command("stop", {})
+        cmds = log.get_by_category("command")
+        assert len(cmds) == 2
+
+    def test_circular_buffer(self):
+        log = SessionLog(max_entries=5)
+        for i in range(10):
+            log.log_command("cmd_%d" % i, {"i": i})
+        assert len(log) == 5
+        recent = log.get_recent(10)
+        assert len(recent) == 5
+
+    def test_clear(self):
+        log = SessionLog()
+        log.log_command("move", {})
+        log.clear()
+        assert len(log) == 0
+
+    def test_log_error_with_details(self):
+        log = SessionLog()
+        log.log_error("fail", {"code": 10})
+        entries = log.get_recent(1)
+        assert entries[0].data["code"] == 10

--- a/tests/host/test_simulator.py
+++ b/tests/host/test_simulator.py
@@ -1,0 +1,106 @@
+import time
+
+import pytest
+
+from shared.enums.command_types import CommandType
+from shared.enums.status_codes import StatusCode
+from host.simulation.simulator import TelescopeSimulator
+
+
+@pytest.fixture
+def sim():
+    return TelescopeSimulator(slew_speed_deg_per_s=100.0)
+
+
+class TestTelescopeSimulator:
+    def test_initial_state_idle(self, sim):
+        state = sim.get_state()
+        assert state.status == StatusCode.IDLE
+        assert state.current_alt_deg == 0.0
+        assert state.current_az_deg == 0.0
+
+    def test_move_command_returns_ack(self, sim):
+        resp = sim.send_command({
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": 45.0,
+            "target_az_deg": 90.0,
+            "speed": 1.0,
+            "command_id": "test-1",
+            "timeout_s": 30.0,
+        })
+        assert resp["message_type"] == "ack"
+
+    def test_focus_in(self, sim):
+        initial = sim.get_state().focus_position
+        sim.send_command({
+            "command_type": CommandType.FOCUS,
+            "direction": "in",
+            "steps": 100,
+            "command_id": "f-1",
+            "timeout_s": 30.0,
+        })
+        state = sim.get_state()
+        assert state.focus_position == initial - 100
+
+    def test_focus_out(self, sim):
+        initial = sim.get_state().focus_position
+        sim.send_command({
+            "command_type": CommandType.FOCUS,
+            "direction": "out",
+            "steps": 200,
+            "command_id": "f-2",
+            "timeout_s": 30.0,
+        })
+        state = sim.get_state()
+        assert state.focus_position == initial + 200
+
+    def test_stop_command(self, sim):
+        sim.send_command({
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": 80.0,
+            "target_az_deg": 180.0,
+            "speed": 0.5,
+            "command_id": "m-1",
+            "timeout_s": 30.0,
+        })
+        time.sleep(0.05)
+        sim.send_command({
+            "command_type": CommandType.STOP,
+            "emergency": False,
+            "command_id": "s-1",
+            "reason": "",
+            "timeout_s": 30.0,
+        })
+        time.sleep(0.1)
+        state = sim.get_state()
+        assert state.status == StatusCode.IDLE
+
+    def test_emergency_stop(self, sim):
+        sim.send_command({
+            "command_type": CommandType.STOP,
+            "emergency": True,
+            "command_id": "es-1",
+            "reason": "test",
+            "timeout_s": 30.0,
+        })
+        state = sim.get_state()
+        assert state.status == StatusCode.EMERGENCY_STOP
+
+    def test_slew_moves_toward_target(self, sim):
+        sim.send_command({
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": 45.0,
+            "target_az_deg": 90.0,
+            "speed": 1.0,
+            "command_id": "m-2",
+            "timeout_s": 30.0,
+        })
+        time.sleep(0.3)
+        state = sim.get_state()
+        assert state.current_alt_deg > 0.0 or state.current_az_deg > 0.0
+
+    def test_status_request(self, sim):
+        resp = sim.send_command({
+            "command_type": CommandType.STATUS_REQUEST,
+        })
+        assert resp["message_type"] == "state_report"

--- a/tests/host/test_telescope_state.py
+++ b/tests/host/test_telescope_state.py
@@ -1,0 +1,74 @@
+import time
+
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.state.telescope_state import HostTelescopeState
+
+
+@pytest.fixture
+def state():
+    return HostTelescopeState()
+
+
+def _make_state(alt=10.0, az=20.0, status=StatusCode.IDLE):
+    return TelescopeState(
+        current_alt_deg=alt,
+        current_az_deg=az,
+        status=status,
+    )
+
+
+class TestHostTelescopeState:
+    def test_initial_state_is_none(self, state):
+        assert state.get_latest() is None
+        assert not state.has_state()
+
+    def test_update_from_pi(self, state):
+        ts = _make_state(alt=45.0, az=90.0)
+        state.update_from_pi(ts)
+        assert state.has_state()
+        latest = state.get_latest()
+        assert latest.current_alt_deg == 45.0
+        assert latest.current_az_deg == 90.0
+
+    def test_get_position(self, state):
+        assert state.get_position() is None
+        ts = _make_state(alt=30.0, az=60.0)
+        state.update_from_pi(ts)
+        pos = state.get_position()
+        assert pos == (30.0, 60.0)
+
+    def test_get_status_default(self, state):
+        assert state.get_status() == StatusCode.IDLE
+
+    def test_get_status_after_update(self, state):
+        ts = _make_state(status=StatusCode.MOVING)
+        state.update_from_pi(ts)
+        assert state.get_status() == StatusCode.MOVING
+
+    def test_seconds_since_update_initial(self, state):
+        assert state.seconds_since_update() == float("inf")
+
+    def test_seconds_since_update_after_update(self, state):
+        ts = _make_state()
+        state.update_from_pi(ts)
+        elapsed = state.seconds_since_update()
+        assert elapsed < 1.0
+
+    def test_set_tracking_target(self, state):
+        state.set_tracking_target("Mars")
+        assert state.get_tracking_target() == "Mars"
+
+    def test_clear_tracking_target(self, state):
+        state.set_tracking_target("Mars")
+        state.clear_tracking_target()
+        assert state.get_tracking_target() is None
+
+    def test_multiple_updates_keeps_latest(self, state):
+        state.update_from_pi(_make_state(alt=10.0, az=20.0))
+        state.update_from_pi(_make_state(alt=50.0, az=100.0))
+        latest = state.get_latest()
+        assert latest.current_alt_deg == 50.0
+        assert latest.current_az_deg == 100.0

--- a/tests/host/test_threading_utils.py
+++ b/tests/host/test_threading_utils.py
@@ -1,0 +1,83 @@
+import threading
+import time
+
+import pytest
+
+from host.utils.threading_utils import PeriodicTask, StoppableThread
+
+
+class TestStoppableThread:
+    def test_start_and_stop(self):
+        called = threading.Event()
+
+        def worker(stop_event):
+            called.set()
+            stop_event.wait()
+
+        st = StoppableThread(target=worker, name="test-thread")
+        st.start()
+        assert called.wait(timeout=1.0)
+        assert st.is_alive()
+        st.stop()
+        assert not st.is_alive()
+
+    def test_double_start_is_safe(self):
+        def worker(stop_event):
+            stop_event.wait()
+
+        st = StoppableThread(target=worker)
+        st.start()
+        st.start()  # should not create a second thread
+        st.stop()
+
+    def test_stop_event_is_accessible(self):
+        def worker(stop_event):
+            stop_event.wait()
+
+        st = StoppableThread(target=worker)
+        assert isinstance(st.stop_event, threading.Event)
+        st.start()
+        st.stop()
+
+
+class TestPeriodicTask:
+    def test_runs_multiple_times(self):
+        counter = {"n": 0}
+        lock = threading.Lock()
+
+        def increment():
+            with lock:
+                counter["n"] += 1
+
+        pt = PeriodicTask(target=increment, hz=100, name="test-periodic")
+        pt.start()
+        time.sleep(0.15)
+        pt.stop()
+
+        with lock:
+            assert counter["n"] >= 5
+
+    def test_stop_halts_execution(self):
+        counter = {"n": 0}
+
+        def increment():
+            counter["n"] += 1
+
+        pt = PeriodicTask(target=increment, hz=100)
+        pt.start()
+        time.sleep(0.05)
+        pt.stop()
+        count_after_stop = counter["n"]
+        time.sleep(0.05)
+        assert counter["n"] == count_after_stop
+
+    def test_is_alive(self):
+        def noop():
+            pass
+
+        pt = PeriodicTask(target=noop, hz=10)
+        assert not pt.is_alive()
+        pt.start()
+        assert pt.is_alive()
+        pt.stop()
+        assert not pt.is_alive()

--- a/tests/host/test_tracking.py
+++ b/tests/host/test_tracking.py
@@ -1,0 +1,135 @@
+import queue
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.state.telescope_state import TelescopeState
+from host.comms.sender import Sender
+from host.control.tracking_controller import TrackingController
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+
+
+def _mock_resolver(name, lat, lon, elev):
+    """Mock coordinate resolver that returns predictable values."""
+    targets = {
+        "mars": (45.0, 20.0, 45.0, 120.0, True),
+        "sirius": (100.0, -16.0, 25.0, 180.0, True),
+        "below_horizon": (0.0, 0.0, -10.0, 0.0, False),
+    }
+    key = name.lower()
+    if key in targets:
+        return targets[key]
+    raise ValueError("Unknown object: %s" % name)
+
+
+@pytest.fixture
+def setup():
+    sl = SessionLog()
+    rq = queue.Queue()
+    sender = MagicMock(spec=Sender)
+    sender.send_move.return_value = "cmd-123"
+    sender.send_stop.return_value = "stop-123"
+
+    ts = HostTelescopeState()
+    ts.update_from_pi(TelescopeState(
+        current_alt_deg=40.0,
+        current_az_deg=115.0,
+        status=StatusCode.IDLE,
+    ))
+
+    tc = TrackingController(
+        sender=sender,
+        telescope_state=ts,
+        session_log=sl,
+        lat=37.0, lon=-122.0, elev=32.0,
+        coordinate_resolver=_mock_resolver,
+    )
+    return tc, sender, ts, sl
+
+
+class TestTrackingController:
+    def test_start_tracking_success(self, setup):
+        tc, sender, ts, sl = setup
+        assert tc.start_tracking("Mars")
+        assert tc.is_tracking
+
+    def test_start_tracking_below_horizon(self, setup):
+        tc, sender, ts, sl = setup
+        assert not tc.start_tracking("below_horizon")
+        assert not tc.is_tracking
+
+    def test_start_tracking_unknown_object(self, setup):
+        tc, sender, ts, sl = setup
+        assert not tc.start_tracking("not_real_xyz")
+        assert not tc.is_tracking
+
+    def test_stop_tracking(self, setup):
+        tc, sender, ts, sl = setup
+        tc.start_tracking("Mars")
+        tc.stop_tracking()
+        assert not tc.is_tracking
+        sender.send_stop.assert_called()
+
+    def test_update_sends_move(self, setup):
+        tc, sender, ts, sl = setup
+        tc.start_tracking("Mars")
+        tc.update()
+        sender.send_move.assert_called()
+
+    def test_update_no_move_when_not_tracking(self, setup):
+        tc, sender, ts, sl = setup
+        tc.update()
+        sender.send_move.assert_not_called()
+
+    def test_update_stops_when_target_sets(self, setup):
+        tc, sender, ts, sl = setup
+        call_count = {"n": 0}
+
+        def resolver(name, lat, lon, elev):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return (45.0, 20.0, 45.0, 120.0, True)
+            return (45.0, 20.0, -5.0, 120.0, False)
+
+        tc._resolve = resolver
+        tc.start_tracking("Mars")
+        tc.update()
+        assert not tc.is_tracking
+
+    def test_get_tracking_info_not_tracking(self, setup):
+        tc, sender, ts, sl = setup
+        info = tc.get_tracking_info()
+        assert info["tracking"] is False
+
+    def test_get_tracking_info_while_tracking(self, setup):
+        tc, sender, ts, sl = setup
+        tc.start_tracking("Mars")
+        info = tc.get_tracking_info()
+        assert info["tracking"] is True
+        assert info["target"] == "Mars"
+        assert info["target_alt"] == pytest.approx(45.0)
+
+    def test_update_within_tolerance_no_move(self, setup):
+        tc, sender, ts, sl = setup
+        ts.update_from_pi(TelescopeState(
+            current_alt_deg=45.0,
+            current_az_deg=120.0,
+            status=StatusCode.IDLE,
+        ))
+        tc.start_tracking("Mars")
+        sender.send_move.reset_mock()
+        tc.update()
+        sender.send_move.assert_not_called()
+
+    def test_tracking_sets_state_target(self, setup):
+        tc, sender, ts, sl = setup
+        tc.start_tracking("Mars")
+        assert ts.get_tracking_target() == "Mars"
+
+    def test_stop_tracking_clears_state_target(self, setup):
+        tc, sender, ts, sl = setup
+        tc.start_tracking("Mars")
+        tc.stop_tracking()
+        assert ts.get_tracking_target() is None

--- a/tests/host/test_validator.py
+++ b/tests/host/test_validator.py
@@ -1,0 +1,58 @@
+import pytest
+
+from shared.enums.command_types import CommandType
+from host.comms.validator import (
+    is_valid_command,
+    validate_incoming_response,
+    validate_outgoing_command,
+)
+
+
+class TestValidateOutgoing:
+    def test_valid_move_command(self):
+        data = {
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": 45.0,
+            "target_az_deg": 90.0,
+            "speed": 0.5,
+        }
+        errors = validate_outgoing_command(data)
+        assert errors == []
+
+    def test_invalid_move_out_of_range(self):
+        data = {
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": 200.0,
+            "target_az_deg": 90.0,
+            "speed": 0.5,
+        }
+        errors = validate_outgoing_command(data)
+        assert len(errors) > 0
+
+    def test_is_valid_command_true(self):
+        data = {
+            "command_type": CommandType.STOP,
+            "emergency": False,
+        }
+        assert is_valid_command(data)
+
+    def test_is_valid_command_false(self):
+        data = {
+            "command_type": CommandType.MOVE,
+            "target_alt_deg": -100.0,
+            "target_az_deg": 0.0,
+            "speed": 0.5,
+        }
+        assert not is_valid_command(data)
+
+
+class TestValidateIncoming:
+    def test_valid_ack(self):
+        data = {"message_type": "ack", "command_id": "abc"}
+        errors = validate_incoming_response(data)
+        assert errors == []
+
+    def test_unknown_message_type(self):
+        data = {"message_type": "unknown"}
+        errors = validate_incoming_response(data)
+        assert len(errors) > 0


### PR DESCRIPTION
## Summary

- Implements all 18 stub files in `host/` — the high-level control layer that runs on the operator's laptop
- Adds 16 test files with 140 new tests (148 total including 8 pre-existing) — **303 tests passing across all layers**
- Host acts as TCP server; Pi connects as client. No hardware-specific code in host/

### What's included

| Module | Key Components |
|--------|---------------|
| **config/** | Network constants, PID gains, observer defaults (Mountain View, CA), UI params |
| **utils/** | `[HOST]` logger, Vincenty angular distance, normalize/clamp, StoppableThread, PeriodicTask |
| **state/** | `HostTelescopeState` (thread-safe Pi state store), `SessionLog` (circular buffer) |
| **comms/** | Message validator, `Receiver` (background recv, state/ack/error dispatch), `Sender` (move/focus/stop with validation + ack waiting) |
| **control/** | `PIDController`, `TrackingController` (celestial resolve + sidereal re-resolve + PID → move), `FocusController` (coarse-to-fine autofocus) |
| **simulation/** | Sample targets/factories, `TelescopeSimulator` (in-process Pi mock with slew physics) |
| **ui/** | Terminal display formatting, `HostInterface` CLI (move, focus, stop, track, autofocus, status, log, help, quit) |
| **main.py** | TCP server bind/accept, tracking background thread, argparse (`--host/--port/--lat/--lon/--elev/--simulate`) |

## Test plan

- [x] `pytest tests/host/ -v` — 148 tests passing
- [x] `pytest tests/ -v` — 303 tests passing (no regressions in shared/ or pi/)
- [x] Import smoke test: `python3 -c "from host.control.tracking_controller import TrackingController; print('OK')"`
- [ ] Integration smoke test: `python3 -m host.main --simulate` (verify CLI starts and commands work)
- [ ] Two-terminal test: `python3 -m host.main` + `python3 pi/main.py --mock --host 127.0.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)