### PR TITLE
test(integration): add end-to-end Host↔Pi communication tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,7 +8,7 @@
 ## Current Status
 
 **Last Updated**: 2026-02-18
-**Branch**: feat/host-control-layer
+**Branch**: main
 **Tests**: 303 passing (86 pi/ + 69 shared/ + 148 host/)
 **Overall Progress**: 3 of 5 layers complete
 
@@ -17,7 +17,7 @@
 ## Completed
 
 ### host/ High-Level Control Layer (2026-02-18)
-- Branch: feat/host-control-layer, pending PR
+- PR #9, merged to main
 - 18 source files + 16 test files (148 tests, including 8 pre-existing)
 - **config/**: constants.py (network, PID, focus, observer defaults), ui_params.py
 - **utils/**: logger.py ([HOST] prefix), math_utils.py (Vincenty angular distance, normalize, clamp, alt_az_delta), threading_utils.py (StoppableThread, PeriodicTask)
@@ -101,3 +101,4 @@ Nothing currently in progress.
   - All 18 stubs replaced with full implementations
   - TCP server, CLI interface, tracking controller, PID, autofocus, simulator
   - 303 total tests passing across all layers
+  - PR #9, squash-merged to main

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,28 +1,29 @@
 # Scratchpad
 
 ## Current Task
-host/ layer implementation complete — ready for PR.
+None — between tasks. All three layers complete and merged.
 
 ## Status
 - [x] Infrastructure: CLAUDE.md, MEMORY.md, scratchpad.md, commands, agents
 - [x] shared/ protocol layer (11 source files, 69 tests) — PR #6 merged
 - [x] pi/ hardware control layer (17 source files, 86 tests) — PR #7 merged
 - [x] Progress tracking system (docs/PROGRESS.md, task board, /save command)
-- [x] host/ layer implementation (18 source files, 148 tests) — on feat/host-control-layer
+- [x] host/ layer implementation (18 source files, 148 tests) — PR #9 merged
 - [ ] Integration testing
 - [ ] Documentation updates
 
 ## Next Steps
-1. Create PR for feat/host-control-layer → main
-2. Integration testing — end-to-end host↔pi communication
-3. Update README.md (remove Java references)
-4. Fill docs/architecture.md
+1. Integration testing — end-to-end host↔pi communication
+2. Update README.md (remove Java references)
+3. Fill docs/architecture.md
+4. Add ruff/mypy to dev dependencies
 
 ## Blockers
 None currently.
 
 ## Notes
 - 303 tests passing (86 pi/ + 69 shared/ + 148 host/)
+- All on main branch — PRs #5, #6, #7, #8, #9 merged
 - Python 3.9 compat: use `Optional[X]`, `List[X]`, `Dict[K,V]`
 - Host is TCP server (Pi connects as client)
 - Simulation mode: `python3 -m host.main --simulate`

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,187 @@
+import queue
+import socket
+import threading
+import time
+from typing import Callable, Optional
+
+import pytest
+
+from host.comms.receiver import Receiver
+from host.comms.sender import Sender
+from host.state.session_logs import SessionLog
+from host.state.telescope_state import HostTelescopeState
+from pi.comms.message_parser import build_state_response
+from pi.comms.tcp_client import TCPClient
+from pi.control.focus_controller import FocusController
+from pi.control.motor_controller import MotorController
+from pi.control.safety_manager import SafetyManager
+from pi.hardware.motor_driver import MockMotorDriver
+from pi.hardware.sensor_reader import MockSensorReader
+from pi.main import _dispatch_command
+from pi.state.error_state import ErrorState
+from pi.state.telescope_state import TelescopeStateManager
+from shared.protocols.tcp_protocol import send_message
+
+
+def wait_for_condition(
+    predicate: Callable[[], bool],
+    timeout: float = 2.0,
+    poll: float = 0.02,
+) -> bool:
+    """Poll until predicate returns True or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return False
+
+
+class StatusRecorder:
+    """Monkey-patches TelescopeStateManager.set_status to record transitions."""
+
+    def __init__(self, state_mgr: TelescopeStateManager) -> None:
+        self._original = state_mgr.set_status
+        self.history: list = []
+        state_mgr.set_status = self._record  # type: ignore[assignment]
+
+    def _record(self, status: str) -> None:
+        self.history.append(status)
+        self._original(status)
+
+
+class IntegrationHarness:
+    """Wires Host and Pi subsystems over real loopback TCP."""
+
+    def __init__(self) -> None:
+        # --- Host side ---
+        self.host_state = HostTelescopeState()
+        self.session_log = SessionLog()
+        self.response_queue: queue.Queue[dict] = queue.Queue()
+        self.sender = Sender(self.session_log, self.response_queue)
+        self.receiver = Receiver(
+            self.host_state, self.session_log, self.response_queue,
+        )
+
+        # --- Pi side ---
+        self.alt_motor = MockMotorDriver()
+        self.az_motor = MockMotorDriver()
+        self.focus_motor = MockMotorDriver()
+        self.sensor_reader = MockSensorReader()
+        self.error_state = ErrorState()
+        self.state_mgr = TelescopeStateManager(self.error_state)
+        self.safety = SafetyManager(
+            self.sensor_reader, self.state_mgr, self.error_state,
+            [self.alt_motor, self.az_motor, self.focus_motor],
+        )
+        self.motor_ctrl = MotorController(
+            self.alt_motor, self.az_motor, self.safety,
+            self.state_mgr, self.error_state,
+        )
+        self.focus_ctrl = FocusController(
+            self.focus_motor, self.safety,
+            self.state_mgr, self.error_state,
+        )
+
+        # Status recorder — captures every set_status() call on the Pi side
+        self.status_recorder = StatusRecorder(self.state_mgr)
+
+        # --- TCP infrastructure ---
+        self._server_sock: Optional[socket.socket] = None
+        self._client_sock: Optional[socket.socket] = None
+        self.tcp_client: Optional[TCPClient] = None
+        self._msg_queue: queue.Queue[dict] = queue.Queue()
+        self._pi_stop = threading.Event()
+        self._pi_thread: Optional[threading.Thread] = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        # 1. TCP server on ephemeral port
+        self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server_sock.bind(("127.0.0.1", 0))
+        self._server_sock.listen(1)
+        port = self._server_sock.getsockname()[1]
+
+        # 2. Pi connects
+        self.tcp_client = TCPClient("127.0.0.1", port, self.error_state)
+        assert self.tcp_client.connect(), "Pi failed to connect"
+
+        # 3. Host accepts
+        self._client_sock, _ = self._server_sock.accept()
+        self._client_sock.settimeout(1.0)
+
+        # 4. Host wiring
+        self.sender.set_socket(self._client_sock)
+        self.receiver.start(self._client_sock)
+
+        # 5. Pi receiver
+        self.tcp_client.start_receiver(self._msg_queue)
+
+        # 6. Pi dispatch thread
+        self._pi_stop.clear()
+        self._pi_thread = threading.Thread(
+            target=self._pi_dispatch_loop,
+            name="pi-dispatch-test",
+            daemon=True,
+        )
+        self._pi_thread.start()
+
+    def stop(self) -> None:
+        # 1. Signal Pi dispatch loop
+        self._pi_stop.set()
+
+        # 2. Stop Host receiver
+        self.receiver.stop()
+
+        # 3. Disconnect Pi
+        if self.tcp_client is not None:
+            self.tcp_client.disconnect()
+
+        # 4. Join Pi dispatch thread
+        if self._pi_thread is not None and self._pi_thread.is_alive():
+            self._pi_thread.join(timeout=2.0)
+
+        # 5. Close sockets
+        for sock in (self._client_sock, self._server_sock):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+    # -- helpers ------------------------------------------------------------
+
+    def send_state_report(self) -> None:
+        """Manually trigger a Pi -> Host state report."""
+        snapshot = self.state_mgr.get_snapshot()
+        self.tcp_client.send(build_state_response(snapshot))
+
+    def send_raw(self, data: dict) -> None:
+        """Send raw data from Host to Pi, bypassing Sender validation."""
+        send_message(self._client_sock, data)
+
+    # -- internal -----------------------------------------------------------
+
+    def _pi_dispatch_loop(self) -> None:
+        while not self._pi_stop.is_set():
+            try:
+                data = self._msg_queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            try:
+                _dispatch_command(
+                    data, self.tcp_client, self.motor_ctrl,
+                    self.focus_ctrl, self.state_mgr,
+                )
+            except Exception:
+                pass  # keep dispatch loop alive
+
+
+@pytest.fixture
+def harness():
+    h = IntegrationHarness()
+    h.start()
+    yield h
+    h.stop()

--- a/tests/integration/test_command_flow.py
+++ b/tests/integration/test_command_flow.py
@@ -1,0 +1,153 @@
+import pytest
+
+from shared.commands.focus_command import FOCUS_IN
+from shared.enums.status_codes import StatusCode
+from tests.integration.conftest import wait_for_condition
+
+
+class TestCommandFlow:
+    def test_move_command_roundtrip(self, harness):
+        """send_move -> Pi acks -> motors step -> position updated."""
+        cmd_id = harness.sender.send_move(45.0, 90.0)
+        assert cmd_id is not None
+
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+        assert ack["command_id"] == cmd_id
+        assert ack["message_type"] == "ack"
+
+        assert wait_for_condition(
+            lambda: harness.alt_motor.cumulative_steps > 0,
+        )
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_position() == (45.0, 90.0),
+        )
+
+    def test_focus_command_roundtrip(self, harness):
+        """send_focus -> Pi acks -> focus motor steps -> focus_position updated."""
+        cmd_id = harness.sender.send_focus(FOCUS_IN, 100)
+        assert cmd_id is not None
+
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+        assert ack["command_id"] == cmd_id
+        assert ack["message_type"] == "ack"
+
+        assert wait_for_condition(
+            lambda: harness.focus_motor.cumulative_steps > 0,
+        )
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_snapshot().focus_position == 100,
+        )
+
+    def test_stop_command_roundtrip(self, harness):
+        """send_stop -> Pi acks -> status returns to IDLE."""
+        cmd_id = harness.sender.send_stop()
+        assert cmd_id is not None
+
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+        assert ack["command_id"] == cmd_id
+
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_status() == StatusCode.IDLE,
+        )
+
+    def test_emergency_stop(self, harness):
+        """send_stop(emergency=True) -> Pi enters EMERGENCY_STOP."""
+        cmd_id = harness.sender.send_stop(emergency=True)
+        assert cmd_id is not None
+
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_status() == StatusCode.EMERGENCY_STOP,
+        )
+
+    def test_status_request_triggers_state_report(self, harness):
+        """send_status_request -> Pi sends state_report -> Host state updated."""
+        assert not harness.host_state.has_state()
+
+        ok = harness.sender.send_status_request()
+        assert ok
+
+        assert wait_for_condition(lambda: harness.host_state.has_state())
+
+    def test_move_then_state_report(self, harness):
+        """Key e2e: move -> execute -> state_report -> Host sees new position."""
+        cmd_id = harness.sender.send_move(30.0, 120.0)
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+
+        # Wait for Pi to finish the move
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_position() == (30.0, 120.0),
+        )
+
+        # Trigger state report -> Host
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: harness.host_state.get_position() == (30.0, 120.0),
+        )
+
+    def test_focus_then_state_report(self, harness):
+        """focus -> execute -> state_report -> Host sees focus_position."""
+        cmd_id = harness.sender.send_focus(FOCUS_IN, 50)
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_snapshot().focus_position == 50,
+        )
+
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: (
+                harness.host_state.get_latest() is not None
+                and harness.host_state.get_latest().focus_position == 50
+            ),
+        )
+
+    def test_multiple_sequential_commands(self, harness):
+        """3 moves in sequence, all acked, final position correct."""
+        positions = [(10.0, 20.0), (30.0, 40.0), (50.0, 60.0)]
+
+        for alt, az in positions:
+            cmd_id = harness.sender.send_move(alt, az)
+            assert cmd_id is not None
+            ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+            assert ack is not None
+            assert wait_for_condition(
+                lambda a=alt, z=az: harness.state_mgr.get_position() == (a, z),
+            )
+
+        assert harness.state_mgr.get_position() == (50.0, 60.0)
+
+    def test_command_ids_preserved(self, harness):
+        """command_id in ack matches what Sender returned."""
+        cmd_id = harness.sender.send_move(20.0, 40.0)
+        assert cmd_id is not None
+
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+        assert ack["command_id"] == cmd_id
+
+    def test_move_sets_status_moving(self, harness):
+        """Pi status transitions through MOVING during a move command."""
+        assert harness.state_mgr.get_status() == StatusCode.IDLE
+
+        cmd_id = harness.sender.send_move(10.0, 20.0)
+        ack = harness.sender.wait_for_ack(cmd_id, timeout=2.0)
+        assert ack is not None
+
+        assert wait_for_condition(
+            lambda: harness.state_mgr.get_position() == (10.0, 20.0),
+        )
+
+        # StatusRecorder captured the MOVING transition
+        assert StatusCode.MOVING in harness.status_recorder.history
+        # Final state is IDLE
+        assert harness.state_mgr.get_status() == StatusCode.IDLE

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -1,0 +1,83 @@
+import time
+
+import pytest
+
+from shared.enums.command_types import CommandType
+from tests.integration.conftest import wait_for_condition
+
+
+class TestErrorHandling:
+    def test_invalid_command_gets_error(self, harness):
+        """Out-of-range values -> Pi sends error response."""
+        harness.send_raw({
+            "command_type": CommandType.MOVE,
+            "command_id": "bad-move-1",
+            "target_alt_deg": -999.0,
+            "target_az_deg": 180.0,
+            "speed": 0.5,
+            "timestamp": time.time(),
+        })
+
+        assert wait_for_condition(
+            lambda: not harness.response_queue.empty(),
+        )
+        msg = harness.response_queue.get(timeout=1.0)
+        assert msg["message_type"] == "error"
+
+    def test_unknown_command_type_error(self, harness):
+        """Unknown command_type -> error response."""
+        harness.send_raw({
+            "command_type": "teleport",
+            "command_id": "unknown-cmd-1",
+            "timestamp": time.time(),
+        })
+
+        assert wait_for_condition(
+            lambda: not harness.response_queue.empty(),
+        )
+        msg = harness.response_queue.get(timeout=1.0)
+        assert msg["message_type"] == "error"
+        assert msg["command_id"] == "unknown-cmd-1"
+
+    def test_error_contains_command_id(self, harness):
+        """Error response carries the original command_id."""
+        test_cmd_id = "error-test-42"
+        harness.send_raw({
+            "command_type": CommandType.MOVE,
+            "command_id": test_cmd_id,
+            "timestamp": time.time(),
+            # Missing target_alt_deg / target_az_deg -> validation failure
+        })
+
+        assert wait_for_condition(
+            lambda: not harness.response_queue.empty(),
+        )
+        msg = harness.response_queue.get(timeout=1.0)
+        assert msg["message_type"] == "error"
+        assert msg["command_id"] == test_cmd_id
+
+    def test_receiver_survives_unknown_message_type(self, harness):
+        """Host Receiver logs warning for unknown type and keeps running."""
+        # Pi sends a message with an unknown message_type
+        harness.tcp_client.send({
+            "message_type": "alien_signal",
+            "data": "beep boop",
+        })
+
+        time.sleep(0.1)
+
+        # Receiver should still be alive
+        assert harness.receiver.is_alive()
+
+        # Confirm by running a real status request through
+        ok = harness.sender.send_status_request()
+        assert ok
+        assert wait_for_condition(lambda: harness.host_state.has_state())
+
+    def test_host_validation_rejects_before_send(self, harness):
+        """send_move(999, 999) returns None — nothing reaches Pi."""
+        cmd_id = harness.sender.send_move(999.0, 999.0)
+        assert cmd_id is None
+
+        time.sleep(0.1)
+        assert harness.alt_motor.cumulative_steps == 0

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -1,0 +1,55 @@
+import threading
+import time
+
+import pytest
+
+from tests.integration.conftest import IntegrationHarness, wait_for_condition
+
+
+class TestLifecycle:
+    def test_clean_connect_disconnect(self):
+        """Harness starts and stops without errors."""
+        h = IntegrationHarness()
+        h.start()
+
+        assert h.tcp_client.is_connected()
+        assert h.receiver.is_alive()
+
+        h.stop()
+
+        assert not h.receiver.is_alive()
+
+    def test_pi_disconnect_detected(self, harness):
+        """Pi disconnects -> Host receiver detects it."""
+        assert harness.receiver.is_alive()
+
+        harness.tcp_client.disconnect()
+
+        assert wait_for_condition(
+            lambda: not harness.receiver.is_alive(),
+            timeout=3.0,
+        )
+
+    def test_commands_work_immediately(self, harness):
+        """Status request succeeds right after setup."""
+        ok = harness.sender.send_status_request()
+        assert ok
+
+        assert wait_for_condition(lambda: harness.host_state.has_state())
+
+    def test_no_thread_leaks(self):
+        """Thread count returns to baseline after harness stop."""
+        # Let any leftover threads from other tests settle
+        time.sleep(0.2)
+        baseline = threading.active_count()
+
+        h = IntegrationHarness()
+        h.start()
+
+        assert threading.active_count() > baseline
+
+        h.stop()
+        time.sleep(0.5)
+
+        final = threading.active_count()
+        assert final <= baseline + 1

--- a/tests/integration/test_state_reporting.py
+++ b/tests/integration/test_state_reporting.py
@@ -1,0 +1,71 @@
+import pytest
+
+from shared.enums.status_codes import StatusCode
+from shared.errors.error_codes import ErrorCode
+from tests.integration.conftest import wait_for_condition
+
+
+class TestStateReporting:
+    def test_state_report_updates_host_position(self, harness):
+        """Manual position change on Pi -> state_report -> Host sees it."""
+        harness.state_mgr.update_position(25.0, 150.0)
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: harness.host_state.get_position() == (25.0, 150.0),
+        )
+
+    def test_state_report_includes_status(self, harness):
+        """Pi status propagates to Host."""
+        harness.state_mgr.set_status(StatusCode.MOVING)
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: harness.host_state.get_status() == StatusCode.MOVING,
+        )
+
+    def test_state_report_includes_focus(self, harness):
+        """Focus position propagates."""
+        harness.state_mgr.set_focus_position(42)
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: (
+                harness.host_state.get_latest() is not None
+                and harness.host_state.get_latest().focus_position == 42
+            ),
+        )
+
+    def test_state_report_includes_errors(self, harness):
+        """Error codes propagate."""
+        harness.error_state.add_error(ErrorCode.MOTOR_TIMEOUT, "test")
+        harness.send_state_report()
+
+        assert wait_for_condition(
+            lambda: (
+                harness.host_state.get_latest() is not None
+                and ErrorCode.MOTOR_TIMEOUT
+                in harness.host_state.get_latest().error_codes
+            ),
+        )
+
+    def test_multiple_state_reports(self, harness):
+        """3 sequential reports, Host tracks each."""
+        positions = [(10.0, 20.0), (30.0, 40.0), (50.0, 60.0)]
+
+        for alt, az in positions:
+            harness.state_mgr.update_position(alt, az)
+            harness.send_state_report()
+            assert wait_for_condition(
+                lambda a=alt, z=az: harness.host_state.get_position() == (a, z),
+            )
+
+    def test_state_report_logged(self, harness):
+        """Session log contains state entry after a state report."""
+        harness.state_mgr.update_position(15.0, 75.0)
+        harness.send_state_report()
+
+        assert wait_for_condition(lambda: harness.host_state.has_state())
+
+        state_entries = harness.session_log.get_by_category("state")
+        assert len(state_entries) > 0


### PR DESCRIPTION
## Summary
- Add 25 integration tests that wire real Host Sender+Receiver against real Pi dispatch loop over loopback TCP
- Proves the full command→ack→state cycle works end-to-end across all three layers (shared/, pi/, host/)
- Total test count: 328 (303 existing + 25 new)

## Test modules
- **test_command_flow** (10 tests): move/focus/stop round-trips, sequential commands, status transitions, state report propagation
- **test_state_reporting** (6 tests): position/status/focus/error propagation from Pi to Host
- **test_error_handling** (5 tests): invalid commands, unknown types, receiver resilience, host-side validation rejection
- **test_lifecycle** (4 tests): connect/disconnect, Pi disconnect detection, thread leak verification

## Test plan
- [x] `pytest tests/integration/ -v` — all 25 integration tests pass
- [x] `pytest tests/ -v` — all 328 tests pass (no regressions)
- [x] No thread leak warnings or socket errors in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)