### PR TITLE
docs: update README and add architecture documentation

### DIFF
--- a/.claude/skills/task-board/SKILL.md
+++ b/.claude/skills/task-board/SKILL.md
@@ -63,9 +63,9 @@
 - [x] tests/host/ (16 test files, 148 tests)
 
 ### Integration & Polish
-- [ ] End-to-end host↔pi communication tests
-- [ ] Update README.md (remove Java references)
-- [ ] Fill docs/architecture.md
+- [x] End-to-end host↔pi communication tests (PR #10, 25 tests)
+- [x] Update README.md (remove Java references, add setup/run instructions)
+- [x] Fill docs/architecture.md (system overview, layers, flows, threading, testing)
 - [ ] Add ruff/mypy to dev dependencies
 
 ---
@@ -77,4 +77,5 @@
 | shared/ | 69 | Passing |
 | pi/ | 86 | Passing |
 | host/ | 148 | Passing |
-| **Total** | **303** | **All passing** |
+| integration/ | 25 | Passing |
+| **Total** | **328** | **All passing** |

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -18,16 +18,17 @@
 - Camera: TBD, will be used for autofocus and plate solving
 
 ## Patterns & Conventions
-- Tests mirror source structure: tests/host/, tests/pi/, tests/shared/
+- Tests mirror source structure: tests/host/, tests/pi/, tests/shared/, tests/integration/
+- Integration tests use IntegrationHarness (real loopback TCP, no mocked sockets)
+- wait_for_condition() polling helper replaces fragile time.sleep() in async tests
 - PYTHONPATH must include repo root for imports to work
 - Case-insensitive celestial object name handling with whitespace trimming
 - Three resolution strategies: solar system DB -> JPL Horizons -> SIMBAD (fallback chain)
 - Thread-safe state management using threading.Lock in pi/state/
 
 ## Implementation Status
-- **Complete**: shared/ (11 files, 69 tests), pi/ (17 files, 86 tests), desired_position.py (8 tests)
-- **Stubs only**: ~18 remaining host/ files
-- **Total tests**: 163 passing
+- **Complete**: shared/ (11 files, 69 tests), pi/ (17 files, 86 tests), host/ (18 files, 148 tests), integration (6 files, 25 tests)
+- **Total tests**: 328 passing
 
 ## Progress Tracking System
 - docs/PROGRESS.md: Primary session-persistent progress tracker (source of truth)
@@ -38,8 +39,6 @@
 - Auto-save: Runs after every commit and at session end (codified in CLAUDE.md)
 
 ## Known Issues
-- README.md mentions Java but project is pure Python — needs updating
-- docs/architecture.md exists but is empty
 - RPi.GPIO / gpiozero not in requirements.txt (only needed on actual Pi)
 - Consider adding ruff, mypy to requirements-dev.txt
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,129 @@
 # Autonomous Tracking and Capturing Telescope
 
-# Overview
+## Overview
 
-This project focuses on designing and building a fully autonomous telescope from individual components, rather than using a prebuilt system. The telescope is capable of automatically focusing, moving, and tracking celestial bodies with minimal human input.
+This project designs and builds a fully autonomous telescope from individual components, rather than using a prebuilt system. The telescope automatically focuses, moves, and tracks celestial bodies with minimal human input.
 
 The system is divided into three major subsystems:
-    Mechanical – Physical structure, mounts, and motion mechanisms
-    Electrical – Motors, sensors, and wiring
-    Software – Control logic, communication, and automation
-    The software stack uses Java (host-side control) and Python (Raspberry Pi integration). Reliable communication across all subsystems is essential to ensure accurate tracking and movement.
 
-# Architecture
+- **Mechanical** -- Physical structure, mounts, and motion mechanisms
+- **Electrical** -- Motors, sensors, and wiring
+- **Software** -- Control logic, communication, and automation
 
-The telescope operates using a host computer ↔ Raspberry Pi architecture:
-    - The host computer performs high-level calculations such as positioning, tracking adjustments, and focus control.
-    - The Raspberry Pi interfaces directly with motors and sensors.
-    - A shared communication layer defines how data and commands are exchanged between the host and the Pi.
+The software stack is pure Python. The host computer handles high-level decision-making (celestial math, tracking, autofocus) while the Raspberry Pi controls hardware (motors, sensors, GPIO). A shared protocol layer defines the communication contract between the two.
 
-This architecture allows decision-making to remain centralized while hardware control stays close to the electronics.
+## Architecture
 
-# Repository Structure
+The telescope operates using a **Host computer <-> Raspberry Pi** architecture:
 
-Host/     → High-level control logic (movement, tracking, focus decisions)  
-Pi/       → Hardware integration and motor/sensor control  
-Shared/   → Communication protocol between Host and Raspberry Pi  
+- The **Host** performs high-level calculations: celestial coordinate resolution (via astropy/astroquery), tracking adjustments (PID control), and autofocus control.
+- The **Raspberry Pi** interfaces directly with stepper motors and sensors, executing movement commands with safety checks.
+- A **shared** communication layer defines commands, state, and the TCP protocol used to exchange data between Host and Pi.
 
-# Setup
+Commands flow **Host -> Pi**. State feedback flows **Pi -> Host**. Both sides use the shared protocol definitions.
 
-Prerequisites: 
+```
+┌─────────────────────┐         TCP          ┌──────────────────────┐
+│       Host          │  ──── commands ────>  │     Raspberry Pi     │
+│                     │                       │                      │
+│  - Celestial math   │  <── state reports ── │  - Motor control     │
+│  - Tracking (PID)   │                       │  - GPIO / sensors    │
+│  - Autofocus        │                       │  - Safety manager    │
+│  - CLI interface    │                       │  - Focus controller  │
+└─────────────────────┘                       └──────────────────────┘
+              │                                         │
+              └──────── shared/ protocol layer ─────────┘
+```
 
-- Java JDK
-- Python 3.11
-- Supported operating system (macOS, Linux, or Windows)
-- Raspberry Pi (for hardware deployment)
+## Repository Structure
+
+```
+auto_telescope/
+├── host/                  # Host computer -- high-level control
+│   ├── main.py            # TCP server, CLI entry point
+│   ├── config/            # Constants, UI params
+│   ├── control/           # Tracking, PID, autofocus, celestial resolution
+│   ├── comms/             # TCP sender/receiver to Pi
+│   ├── state/             # Telescope state store, session logs
+│   ├── ui/                # CLI interface, display formatting
+│   ├── simulation/        # Testing without hardware
+│   └── utils/             # Logger, math, threading helpers
+├── pi/                    # Raspberry Pi -- hardware control
+│   ├── main.py            # Hardware init, 50Hz dispatch loop
+│   ├── config/            # Constants, GPIO pin mappings
+│   ├── control/           # Motor controller, focus, safety manager
+│   ├── hardware/          # GPIO setup, motor driver, sensors
+│   ├── comms/             # TCP client, message parser
+│   ├── state/             # Position tracking, error state
+│   └── utils/             # Logger, timer, debug
+├── shared/                # Communication contract (Host <-> Pi)
+│   ├── commands/          # Move, Focus, Stop command definitions
+│   ├── enums/             # CommandType, StatusCode
+│   ├── errors/            # ErrorCode definitions
+│   ├── protocols/         # TCP protocol (4-byte length-prefixed JSON), validator
+│   └── state/             # TelescopeState, CameraState
+├── tests/                 # Test suite (328 tests)
+│   ├── host/              # Host unit tests (148)
+│   ├── pi/                # Pi unit tests (86)
+│   ├── shared/            # Shared unit tests (69)
+│   └── integration/       # End-to-end Host<->Pi tests (25)
+├── docs/                  # Architecture docs, progress log
+├── .github/workflows/     # CI pipeline
+└── requirements.txt       # astropy, astroquery, pytest
+```
+
+## Setup
+
+### Prerequisites
+
+- Python 3.9+
+- Raspberry Pi (for hardware deployment; mock hardware available for development)
+
+### Installation
+
+```bash
+git clone https://github.com/MVHS-Physics-Astro-Club-Telescope/auto_telescope.git
+cd auto_telescope
+pip install -r requirements.txt
+```
+
+### Running
+
+**Host (with simulation mode -- no Pi needed):**
+```bash
+export PYTHONPATH=$PWD:$PYTHONPATH
+python3 -m host.main --simulate
+```
+
+**Host (connecting to a real Pi):**
+```bash
+python3 -m host.main --host 0.0.0.0 --port 5050
+```
+
+**Pi (with mock hardware -- no GPIO needed):**
+```bash
+python3 pi/main.py --mock --host <host-ip>
+```
+
+**Pi (with real hardware):**
+```bash
+python3 pi/main.py --host <host-ip>
+```
+
+### Running Tests
+
+```bash
+export PYTHONPATH=$PWD:$PYTHONPATH
+pytest tests/ -v
+```
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Language | Python 3.9+ |
+| Celestial math | astropy, astroquery (SIMBAD, JPL Horizons) |
+| Hardware I/O | RPi.GPIO (on Pi only) |
+| Communication | TCP sockets (4-byte length-prefixed JSON) |
+| Testing | pytest (328 tests) |
+| CI | GitHub Actions (Python 3.9, 3.10) |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -9,12 +9,21 @@
 
 **Last Updated**: 2026-02-18
 **Branch**: main
-**Tests**: 303 passing (86 pi/ + 69 shared/ + 148 host/)
-**Overall Progress**: 3 of 5 layers complete
+**Tests**: 328 passing (86 pi/ + 69 shared/ + 148 host/ + 25 integration/)
+**Overall Progress**: 3 of 5 layers complete + integration tests
 
 ---
 
 ## Completed
+
+### Integration Tests (2026-02-18)
+- PR #10, merged to main
+- 6 files: conftest.py (IntegrationHarness) + 4 test modules (25 tests)
+- **test_command_flow** (10): move/focus/stop round-trips, sequential commands, status transitions, state report propagation
+- **test_state_reporting** (6): position/status/focus/error propagation from Pi to Host
+- **test_error_handling** (5): invalid commands, unknown types, receiver resilience, host-side validation rejection
+- **test_lifecycle** (4): connect/disconnect, Pi disconnect detection, thread leak verification
+- IntegrationHarness wires real Host Sender+Receiver against real Pi dispatch loop over loopback TCP
 
 ### host/ High-Level Control Layer (2026-02-18)
 - PR #9, merged to main
@@ -68,9 +77,7 @@ Nothing currently in progress.
 
 ## Next Up (Priority Order)
 
-1. **Integration testing** — End-to-end host↔pi communication tests
-2. **Documentation** — Update README.md (still references Java), fill docs/architecture.md
-3. **Dev tooling** — Add ruff, mypy to requirements-dev.txt
+1. **Dev tooling** — Add ruff, mypy to requirements-dev.txt
 
 ---
 
@@ -82,8 +89,6 @@ Nothing currently in progress.
 
 ## Known Issues
 
-- README.md mentions Java but project is pure Python — needs updating
-- docs/architecture.md exists but is empty
 - CI uses Python 3.9/3.10 — requirements.txt is minimal (astropy, astroquery, pytest)
 - RPi.GPIO / gpiozero not in requirements.txt (only needed on Pi hardware)
 - Consider adding ruff, mypy to requirements-dev.txt
@@ -102,3 +107,9 @@ Nothing currently in progress.
   - TCP server, CLI interface, tracking controller, PID, autofocus, simulator
   - 303 total tests passing across all layers
   - PR #9, squash-merged to main
+- Added 25 end-to-end integration tests (Host↔Pi over loopback TCP)
+  - IntegrationHarness wires real components, no mocked sockets
+  - 328 total tests passing across all layers
+  - PR #10, squash-merged to main
+- Updated README.md (removed Java references, added setup/run instructions, architecture diagram)
+- Filled docs/architecture.md (full system overview, layer details, communication flows, threading model, testing strategy)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,238 @@
+# Architecture
+
+## System Overview
+
+The telescope software is a two-process system connected over TCP:
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│                         Host Computer                             │
+│                                                                   │
+│  ┌──────────┐  ┌──────────────┐  ┌────────────┐  ┌───────────┐  │
+│  │ CLI / UI │  │   Tracking   │  │  Autofocus  │  │ Celestial │  │
+│  │          │  │  Controller  │  │ Controller  │  │ Resolver  │  │
+│  └────┬─────┘  └──────┬───────┘  └─────┬──────┘  └─────┬─────┘  │
+│       │               │                │               │         │
+│       └───────────┬────┴────────────────┴───────────────┘         │
+│                   │                                               │
+│  ┌────────────────▼──────────────────┐  ┌──────────────────────┐ │
+│  │  Sender (send_move/focus/stop)    │  │  HostTelescopeState  │ │
+│  └────────────────┬──────────────────┘  └──────────▲───────────┘ │
+│                   │                                │              │
+│  ┌────────────────▼──────────────────────────────┐ │              │
+│  │          TCP Server (port 5050)                │ │              │
+│  │  ┌──────────────────────────────────────────┐ │ │              │
+│  │  │ Receiver (background thread)             │─┼─┘              │
+│  │  │  - state_report -> HostTelescopeState    │ │                │
+│  │  │  - ack/error -> response_queue           │ │                │
+│  │  └──────────────────────────────────────────┘ │                │
+│  └───────────────────────────────────────────────┘                │
+└───────────────────────────┬───────────────────────────────────────┘
+                            │  TCP (4-byte length-prefixed JSON)
+                            │
+                  ┌─────────┴─────────┐
+                  │  shared/ protocol  │
+                  │  - MoveCommand     │
+                  │  - FocusCommand    │
+                  │  - StopCommand     │
+                  │  - TelescopeState  │
+                  │  - StatusCode      │
+                  │  - ErrorCode       │
+                  └─────────┬─────────┘
+                            │
+┌───────────────────────────▼───────────────────────────────────────┐
+│                       Raspberry Pi                                │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐    │
+│  │  TCPClient (connect, background receiver, send)           │    │
+│  └───────────────────────┬───────────────────────────────────┘    │
+│                          │                                        │
+│  ┌───────────────────────▼───────────────────────────────────┐    │
+│  │  Main Loop (50 Hz, single-threaded)                       │    │
+│  │  - Pull from msg_queue                                    │    │
+│  │  - _dispatch_command() -> ack + execute                   │    │
+│  │  - Periodic state reports (5 Hz)                          │    │
+│  │  - Safety checks every tick                               │    │
+│  └──────┬─────────────────┬──────────────────┬───────────────┘    │
+│         │                 │                  │                    │
+│  ┌──────▼──────┐  ┌───────▼───────┐  ┌──────▼──────────┐        │
+│  │   Motor     │  │    Focus      │  │  Safety         │        │
+│  │  Controller │  │  Controller   │  │  Manager        │        │
+│  │             │  │               │  │                  │        │
+│  │ - alt axis  │  │ - position    │  │ - limit switches │        │
+│  │ - az axis   │  │   tracking    │  │ - position bounds│        │
+│  │ - chunked   │  │ - in/out      │  │ - watchdog       │        │
+│  │   stepping  │  │               │  │ - emergency stop │        │
+│  └──────┬──────┘  └───────┬───────┘  └──────┬──────────┘        │
+│         │                 │                  │                    │
+│  ┌──────▼─────────────────▼──────────────────▼───────────────┐    │
+│  │  Hardware ABCs (MotorDriver, SensorReader, GPIOProvider)  │    │
+│  │  - StepperMotorDriver / MockMotorDriver                   │    │
+│  │  - GPIOSensorReader / MockSensorReader                    │    │
+│  │  - HardwareGPIOProvider / MockGPIOProvider                │    │
+│  └───────────────────────────────────────────────────────────┘    │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## Layers
+
+### shared/ -- Protocol Contract
+
+The shared layer defines the communication contract consumed by both Host and Pi. Neither side imports the other; they only import shared.
+
+**Commands** (Host -> Pi):
+- `MoveCommand` -- target alt/az in degrees, speed (0-1), timeout
+- `FocusCommand` -- direction (in/out), steps, timeout
+- `StopCommand` -- emergency flag, reason string
+
+**State** (Pi -> Host):
+- `TelescopeState` -- current position, status, target, error codes, focus position, tracking flag
+
+**Protocol**:
+- TCP with 4-byte big-endian length prefix followed by UTF-8 JSON payload
+- Max message size: 64 KB
+- Message types: command (Host->Pi), ack/error/state_report (Pi->Host)
+- `MessageValidator` enforces ranges (alt 0-90, az 0-360, speed 0-1, focus steps 1-10000)
+
+**Enums**:
+- `CommandType`: MOVE, FOCUS, STOP, STATUS_REQUEST
+- `StatusCode`: IDLE, MOVING, FOCUSING, EMERGENCY_STOP, OK, BUSY, ERROR
+- `ErrorCode`: Motor (10-19), Position (20-29), Focus (30-39), Comms (40-49), Camera (50-59), Sensor (60-69), Safety (70-79)
+
+### host/ -- High-Level Control
+
+The Host is hardware-agnostic. It never references GPIO pins, motor drivers, or Pi-specific values.
+
+**Control flow**:
+1. `main.py` starts a TCP server and waits for Pi to connect
+2. Once connected, the CLI (`host_interface.py`) accepts user commands
+3. Commands are validated (`validator.py`), serialized, and sent via `Sender`
+4. `Receiver` runs a background thread processing incoming messages:
+   - `state_report` -> updates `HostTelescopeState`
+   - `ack` / `error` -> routes to `response_queue` for `Sender.wait_for_ack()`
+
+**Tracking loop** (`tracking_controller.py`):
+1. Resolve target name to RA/Dec via astropy/astroquery (`desired_position.py`)
+2. Convert RA/Dec to Alt/Az for current time and observer location
+3. Compare with current position from `HostTelescopeState`
+4. Apply PID correction (`error_correction.py`)
+5. Send move command if error exceeds tolerance (0.01 deg)
+6. Re-resolve periodically for sidereal motion
+
+**Autofocus** (`focus_controller.py`):
+- Coarse-to-fine search: steps of [100, 50, 25, 10]
+- Moves focus in/out, compares metric, converges on best position
+
+**Simulation mode** (`--simulate`):
+- `Simulator` replaces the TCP connection with an in-process mock Pi
+- Simulates slew motion, focus, and state reporting
+- Enables full Host testing without any hardware or network
+
+### pi/ -- Hardware Control
+
+The Pi is logic-agnostic. It executes commands, doesn't decide what to track. All celestial math stays on the Host.
+
+**Main loop** (`main.py`):
+- Single-threaded at 50 Hz with `LoopTimer`
+- Each tick: feed watchdog, safety check, process one command from queue, periodic state report at 5 Hz
+- `_dispatch_command()`: validate -> ack -> execute (move/focus/stop)
+
+**Motor control** (`motor_controller.py`):
+- Converts degrees to steps using `STEPS_PER_DEGREE` constants
+- Chunked stepping (50 steps/chunk) with `stop_event` for responsive cancellation
+- Moves alt axis first, then az axis (sequential, not simultaneous)
+- Speed maps linearly from 0-1 to MIN_STEP_RATE_HZ - MAX_STEP_RATE_HZ
+
+**Safety manager** (`safety_manager.py`):
+- Last line of defense -- checked every tick
+- Limit switches: triggers emergency stop if any switch is hit
+- Position bounds: alt [0, 90], az [0, 360]
+- Watchdog: emergency stop if not fed within timeout
+- Emergency stop: disables all motors, sets EMERGENCY_STOP status
+
+**Hardware abstraction**:
+- `MotorDriver` ABC with `StepperMotorDriver` (real) and `MockMotorDriver` (testing)
+- `SensorReader` ABC with `GPIOSensorReader` (real) and `MockSensorReader` (testing)
+- `GPIOProvider` ABC with `HardwareGPIOProvider` (RPi.GPIO) and `MockGPIOProvider` (testing)
+- RPi.GPIO is imported lazily (only in `HardwareGPIOProvider.__init__`), so all Pi code is importable on non-Pi systems
+
+## Communication Flow
+
+### Command round-trip (Host sends move):
+
+```
+Host                              Pi
+ │                                 │
+ │  MoveCommand (JSON over TCP)    │
+ │ ──────────────────────────────> │
+ │                                 │  validate -> is_valid_command()
+ │         ack response            │
+ │ <────────────────────────────── │
+ │                                 │  motor_ctrl.execute_move()
+ │                                 │    set_status(MOVING)
+ │                                 │    step alt motor (chunked)
+ │                                 │    step az motor (chunked)
+ │                                 │    update_position()
+ │                                 │    set_status(IDLE)
+ │                                 │
+ │         state_report            │  (periodic, 5 Hz)
+ │ <────────────────────────────── │
+ │                                 │
+ │  update HostTelescopeState      │
+ │                                 │
+```
+
+### Error flow (invalid command):
+
+```
+Host                              Pi
+ │                                 │
+ │  Invalid command (raw TCP)      │
+ │ ──────────────────────────────> │
+ │                                 │  is_valid_command() -> False
+ │       error response            │
+ │ <────────────────────────────── │  build_error_response(cmd_id, msg)
+ │                                 │
+ │  routes to response_queue       │
+ │                                 │
+```
+
+## Threading Model
+
+**Host** (3 threads during operation):
+1. Main thread -- CLI input loop
+2. Receiver thread -- `recv_message()` loop, dispatches to state/queue
+3. Tracking thread (optional) -- periodic PID updates when tracking
+
+**Pi** (2 threads during operation):
+1. Main thread -- 50 Hz dispatch loop
+2. TCPClient receiver thread -- `recv()` loop, puts messages on queue
+
+All shared state is protected by `threading.Lock`. The Pi's main loop is deliberately single-threaded to avoid hardware contention.
+
+## Testing Strategy
+
+| Layer | Approach | Count |
+|-------|----------|-------|
+| shared/ | Pure unit tests on data classes, protocol, validation | 69 |
+| pi/ | Unit tests with MockMotorDriver, MockSensorReader, MockGPIOProvider | 86 |
+| host/ | Unit tests with mocked Sender, socket pairs, mock resolvers | 148 |
+| integration/ | Real loopback TCP, IntegrationHarness wires both sides | 25 |
+| **Total** | | **328** |
+
+**Integration test harness** (`tests/integration/conftest.py`):
+- Creates a TCP server on an ephemeral port (`127.0.0.1:0`)
+- Wires real Host Sender+Receiver against real Pi dispatch loop
+- Pi dispatch runs in a background thread with `_dispatch_command()` imported from `pi.main`
+- State reports triggered manually for deterministic assertions
+- `wait_for_condition()` polling replaces `time.sleep()` for reliable async testing
+
+## Key Design Decisions
+
+1. **Host is the TCP server, Pi is the client** -- Pi connects to Host on startup, enabling the Host to be started first and wait for Pi
+2. **Ack before execute** -- Pi sends ack immediately upon receiving a valid command, then executes it. This unblocks the Host's `wait_for_ack()` quickly
+3. **Chunked stepping** -- Motor moves are broken into 50-step chunks, checking `stop_event` between chunks for responsive cancellation
+4. **Sequential axis movement** -- Alt moves first, then Az (not simultaneous). Simpler, avoids concurrent motor driver access
+5. **All time in UTC** -- Internal timestamps use UTC. Display layer converts to local time
+6. **Hardware behind ABCs** -- Every hardware interface has a mock implementation, enabling full test coverage without physical hardware
+7. **Shared is sacred** -- Any change to shared/ requires updating both Host and Pi. The protocol is the contract

--- a/scratchpad.md
+++ b/scratchpad.md
@@ -1,7 +1,7 @@
 # Scratchpad
 
 ## Current Task
-None — between tasks. All three layers complete and merged.
+None — between tasks. Documentation updates complete.
 
 ## Status
 - [x] Infrastructure: CLAUDE.md, MEMORY.md, scratchpad.md, commands, agents
@@ -9,21 +9,20 @@ None — between tasks. All three layers complete and merged.
 - [x] pi/ hardware control layer (17 source files, 86 tests) — PR #7 merged
 - [x] Progress tracking system (docs/PROGRESS.md, task board, /save command)
 - [x] host/ layer implementation (18 source files, 148 tests) — PR #9 merged
-- [ ] Integration testing
-- [ ] Documentation updates
+- [x] Integration testing (6 files, 25 tests) — PR #10 merged
+- [x] Documentation updates (README.md, docs/architecture.md)
+- [ ] Dev tooling (ruff, mypy)
 
 ## Next Steps
-1. Integration testing — end-to-end host↔pi communication
-2. Update README.md (remove Java references)
-3. Fill docs/architecture.md
-4. Add ruff/mypy to dev dependencies
+1. Add ruff/mypy to dev dependencies
 
 ## Blockers
 None currently.
 
 ## Notes
-- 303 tests passing (86 pi/ + 69 shared/ + 148 host/)
-- All on main branch — PRs #5, #6, #7, #8, #9 merged
+- 328 tests passing (86 pi/ + 69 shared/ + 148 host/ + 25 integration/)
+- All on main branch — PRs #5, #6, #7, #8, #9, #10 merged
 - Python 3.9 compat: use `Optional[X]`, `List[X]`, `Dict[K,V]`
 - Host is TCP server (Pi connects as client)
 - Simulation mode: `python3 -m host.main --simulate`
+- Integration tests use real loopback TCP (no mocked sockets)


### PR DESCRIPTION
## Summary
- Rewrite README.md: remove Java references, add architecture diagram, repo structure, setup/run instructions, tech stack table
- Fill docs/architecture.md from empty: full system overview with ASCII component diagrams, layer details, command/error flow sequences, threading model, testing strategy, key design decisions
- Update progress tracking files (PROGRESS.md, scratchpad.md, MEMORY.md, task board)

## Test plan
- [ ] No code changes — documentation only
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)