### PR TITLE
fix: critical hardware deployment bugs

### DIFF
--- a/host/control/desired_position.py
+++ b/host/control/desired_position.py
@@ -1,7 +1,11 @@
+import logging
+
 from astropy.coordinates import SkyCoord, EarthLocation, AltAz, get_body
 from astropy.time import Time
 from astroquery.jplhorizons import Horizons
 import astropy.units as u
+
+logger = logging.getLogger("desired_position")
 
 def get_object_coordinates(name, lat, lon, elevation):
     """
@@ -30,8 +34,8 @@ def get_object_coordinates(name, lat, lon, elevation):
             body = get_body(name_lower, t)
             ra = body.ra.deg
             dec = body.dec.deg
-        except:
-            pass
+        except Exception as e:
+            logger.warning("Failed to resolve solar system body '%s': %s", name_lower, e)
         else:
             altaz = body.transform_to(AltAz(obstime=t, location=location))
             alt_deg = altaz.alt.deg
@@ -45,8 +49,8 @@ def get_object_coordinates(name, lat, lon, elevation):
         eph = obj.ephemerides()
         ra = float(eph['RA'][0])
         dec = float(eph['DEC'][0])
-    except:
-        pass
+    except Exception as e:
+        logger.warning("Failed to resolve '%s' via JPL Horizons: %s", name_original, e)
     else:
         coord = SkyCoord(ra=ra * u.deg, dec=dec * u.deg)
         altaz = coord.transform_to(AltAz(obstime=t, location=location))
@@ -58,8 +62,8 @@ def get_object_coordinates(name, lat, lon, elevation):
     # SIMBAD / Name resolution (keep original case)
     try:
         coord = SkyCoord.from_name(name_original)
-    except:
-        pass
+    except Exception as e:
+        logger.warning("Failed to resolve '%s' via SIMBAD: %s", name_original, e)
     else:
         ra = coord.ra.deg
         dec = coord.dec.deg

--- a/host/utils/threading_utils.py
+++ b/host/utils/threading_utils.py
@@ -1,6 +1,9 @@
+import logging
 import threading
 import time
 from typing import Callable, Optional
+
+logger = logging.getLogger("threading_utils")
 
 
 class StoppableThread:
@@ -83,7 +86,7 @@ class PeriodicTask:
             try:
                 self._target()
             except Exception:
-                pass
+                logger.exception("PeriodicTask error")
             elapsed = time.monotonic() - start
             sleep_time = self._interval - elapsed
             if sleep_time > 0:

--- a/pi/config/constants.py
+++ b/pi/config/constants.py
@@ -1,8 +1,13 @@
-# Motor parameters
-STEPS_PER_DEGREE_ALT = 200.0
-STEPS_PER_DEGREE_AZ = 200.0
+# Motor parameters — derivation
+MOTOR_STEPS_PER_REV = 200
+BELT_RATIO = 10.0
+MICROSTEP_FACTOR = 16
+STEPS_PER_DEGREE_ALT = MOTOR_STEPS_PER_REV * BELT_RATIO * MICROSTEP_FACTOR / 360.0  # ~88.9
+STEPS_PER_DEGREE_AZ = MOTOR_STEPS_PER_REV * BELT_RATIO * MICROSTEP_FACTOR / 360.0   # ~88.9
 MAX_STEP_RATE_HZ = 1000
 MIN_STEP_RATE_HZ = 10
+# TODO: ACCEL_STEPS_PER_S2 is defined but not yet used in the motion planner;
+# implement acceleration ramp in MotorController.step() when hardware is ready.
 ACCEL_STEPS_PER_S2 = 500
 
 # Control loop

--- a/pi/control/focus_controller.py
+++ b/pi/control/focus_controller.py
@@ -23,6 +23,8 @@ class FocusController:
         self._safety = safety
         self._state = state_manager
         self._errors = error_state
+        # TODO: _position = 0 assumes the focuser is homed at startup;
+        # implement a homing routine or load last known position from persistent storage.
         self._position = 0
 
     def execute_focus(self, cmd: FocusCommand) -> bool:

--- a/pi/hardware/motor_driver.py
+++ b/pi/hardware/motor_driver.py
@@ -48,6 +48,10 @@ class StepperMotorDriver(MotorDriver):
         self._gpio = gpio
         self._pins = pins
         self._enabled = False
+        # Explicitly disable motor at init — GPIO setup may default the enable
+        # pin to LOW which is "enabled" under TMC2209 active-LOW convention.
+        # Park in disabled state until step() explicitly calls enable().
+        self._gpio.write(self._pins.enable, HIGH)
 
     def enable(self) -> None:
         # TMC2209 ENN pin is active-LOW: LOW = enabled, HIGH = disabled

--- a/pi/hardware/motor_driver.py
+++ b/pi/hardware/motor_driver.py
@@ -50,11 +50,13 @@ class StepperMotorDriver(MotorDriver):
         self._enabled = False
 
     def enable(self) -> None:
-        self._gpio.write(self._pins.enable, HIGH)
+        # TMC2209 ENN pin is active-LOW: LOW = enabled, HIGH = disabled
+        self._gpio.write(self._pins.enable, LOW)
         self._enabled = True
 
     def disable(self) -> None:
-        self._gpio.write(self._pins.enable, LOW)
+        # TMC2209 ENN pin is active-LOW: LOW = enabled, HIGH = disabled
+        self._gpio.write(self._pins.enable, HIGH)
         self._enabled = False
 
     def step(

--- a/pi/hardware/sensor_reader.py
+++ b/pi/hardware/sensor_reader.py
@@ -51,6 +51,8 @@ class GPIOSensorReader(SensorReader):
         )
 
     def read_encoders(self) -> EncoderReading:
+        # TODO: read_encoders() is a stub awaiting hardware integration;
+        # replace with actual I2C/SPI encoder reads once hardware is connected.
         return EncoderReading()
 
 


### PR DESCRIPTION
## Summary
- Fix motor enable pin polarity (TMC2209 active-LOW, was writing HIGH)
- Fix steps-per-degree calculation (200 → 88.9 with derived constants)
- Replace bare `except:` with `except Exception as e:` + logging
- Log PeriodicTask exceptions instead of silently swallowing
- Add TODO comments for known hardware integration gaps

## Why
Codebase audit identified 2 CRITICAL bugs that would prevent any motor movement on first hardware deployment, plus 3 HIGH severity issues that would cause silent failures and masked errors.

## Test plan
- [x] All 320 tests pass on the fix branch
- [ ] Verify enable pin polarity on actual TMC2209 hardware with multimeter
- [ ] Verify steps-per-degree with physical angle measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)